### PR TITLE
Added option to use custom TLS certificates instead of ACME

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ applications. To enable this, add the `--tls` flag when deploying an instance:
     kamal-proxy deploy service1 --target web-1:3000 --host app1.example.com --tls
 
 
+### Custom TLS certificate
+
+When you obtained your TLS certificate manually, manage your own certificate authority,
+or need to install Cloudflare origin certificate, you can manually specify path to
+your certificate file and the corresponding private key:
+
+    kamal-proxy deploy service1 --target web-1:3000 --host app1.example.com --tls --tls-certificate-path cert.pem --tls-private-key-path key.pem
+
+
 ## Specifying `run` options with environment variables
 
 In some environments, like when running a Docker container, it can be convenient

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -31,8 +31,8 @@ func newDeployCommand() *deployCommand {
 
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSEnabled, "tls", false, "Configure TLS for this target (requires a non-empty host)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
-	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "")
-	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "Configure custom TLS certificate path (PEM format)")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "Configure custom TLS private key path (PEM format)")
 
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DeployTimeout, "deploy-timeout", server.DefaultDeployTimeout, "Maximum time to wait for the new target to become healthy")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DrainTimeout, "drain-timeout", server.DefaultDrainTimeout, "Maximum time to allow existing connections to drain before removing old target")

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -10,11 +10,9 @@ import (
 )
 
 type deployCommand struct {
-	cmd                *cobra.Command
-	args               server.DeployArgs
-	tlsStaging         bool
-	tlsCertificatePath string
-	tlsPrivateKeyPath  string
+	cmd        *cobra.Command
+	args       server.DeployArgs
+	tlsStaging bool
 }
 
 func newDeployCommand() *deployCommand {
@@ -33,8 +31,8 @@ func newDeployCommand() *deployCommand {
 
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSEnabled, "tls", false, "Configure TLS for this target (requires a non-empty host)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
-	deployCommand.cmd.Flags().StringVar(&deployCommand.tlsCertificatePath, "tls-certificate-path", "", "")
-	deployCommand.cmd.Flags().StringVar(&deployCommand.tlsPrivateKeyPath, "tls-private-key-path", "", "")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "")
 
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DeployTimeout, "deploy-timeout", server.DefaultDeployTimeout, "Maximum time to wait for the new target to become healthy")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DrainTimeout, "drain-timeout", server.DefaultDrainTimeout, "Maximum time to allow existing connections to drain before removing old target")
@@ -57,6 +55,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.TargetOptions.ForwardHeaders, "forward-headers", false, "Forward X-Forwarded headers to target (default false if TLS enabled; otherwise true)")
 
 	deployCommand.cmd.MarkFlagRequired("target")
+	deployCommand.cmd.MarkFlagsRequiredTogether("tls-certificate-path", "tls-private-key-path")
 
 	return deployCommand
 }
@@ -66,8 +65,6 @@ func (c *deployCommand) run(cmd *cobra.Command, args []string) error {
 
 	if c.args.ServiceOptions.TLSEnabled {
 		c.args.ServiceOptions.ACMECachePath = globalConfig.CertificatePath()
-		c.args.ServiceOptions.TLSCertificatePath = c.tlsCertificatePath
-		c.args.ServiceOptions.TLSPrivateKeyPath = c.tlsPrivateKeyPath
 
 		if c.tlsStaging {
 			c.args.ServiceOptions.ACMEDirectory = server.ACMEStagingDirectoryURL
@@ -91,14 +88,6 @@ func (c *deployCommand) preRun(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flags().Changed("tls") && !cmd.Flags().Changed("host") {
 		return fmt.Errorf("host must be set when using TLS")
-	}
-
-	if cmd.Flags().Changed("tls-certificate-path") && !cmd.Flags().Changed("tls-private-key-path") {
-		return fmt.Errorf("tls-private-key-path must be set when specified tls-certificate-path")
-	}
-
-	if cmd.Flags().Changed("tls-private-key-path") && !cmd.Flags().Changed("tls-certificate-path") {
-		return fmt.Errorf("tls-certificate-path must be set when specified tls-private-key-path")
 	}
 
 	if !cmd.Flags().Changed("forward-headers") {

--- a/internal/server/cert.go
+++ b/internal/server/cert.go
@@ -3,11 +3,13 @@ package server
 import (
 	"crypto/tls"
 	"log/slog"
+	"net/http"
 	"sync"
 )
 
 type CertManager interface {
 	GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
+	HTTPHandler(handler http.Handler) http.Handler
 }
 
 // StaticCertManager is a certificate manager that loads certificates from disk.
@@ -52,4 +54,8 @@ func (m *StaticCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certifica
 	m.cert = &cert
 
 	return m.cert, nil
+}
+
+func (m *StaticCertManager) HTTPHandler(handler http.Handler) http.Handler {
+	return handler
 }

--- a/internal/server/cert.go
+++ b/internal/server/cert.go
@@ -9,9 +9,11 @@ type CertManager interface {
 	GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
 }
 
+// StaticCertManager is a certificate manager that loads certificates from disk.
 type StaticCertManager struct {
 	tlsCertificateFilePath string
 	tlsPrivateKeyFilePath  string
+	cert                   *tls.Certificate
 }
 
 func NewStaticCertManager(tlsCertificateFilePath, tlsPrivateKeyFilePath string) *StaticCertManager {
@@ -22,6 +24,10 @@ func NewStaticCertManager(tlsCertificateFilePath, tlsPrivateKeyFilePath string) 
 }
 
 func (m *StaticCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if m.cert != nil {
+		return m.cert, nil
+	}
+
 	slog.Info(
 		"Loading custom TLS certificate",
 		"tls-certificate-path", m.tlsCertificateFilePath,
@@ -32,6 +38,7 @@ func (m *StaticCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certifica
 	if err != nil {
 		return nil, err
 	}
+	m.cert = &cert
 
-	return &cert, nil
+	return m.cert, nil
 }

--- a/internal/server/cert.go
+++ b/internal/server/cert.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"crypto/tls"
+	"log/slog"
+)
+
+type CertManager interface {
+	GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
+}
+
+type StaticCertManager struct {
+	tlsCertificateFilePath string
+	tlsPrivateKeyFilePath  string
+}
+
+func NewStaticCertManager(tlsCertificateFilePath, tlsPrivateKeyFilePath string) *StaticCertManager {
+	return &StaticCertManager{
+		tlsCertificateFilePath: tlsCertificateFilePath,
+		tlsPrivateKeyFilePath:  tlsPrivateKeyFilePath,
+	}
+}
+
+func (m *StaticCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	slog.Info(
+		"Loading custom TLS certificate",
+		"tls-certificate-path", m.tlsCertificateFilePath,
+		"tls-private-key-path", m.tlsPrivateKeyFilePath,
+	)
+
+	cert, err := tls.LoadX509KeyPair(m.tlsCertificateFilePath, m.tlsPrivateKeyFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cert, nil
+}

--- a/internal/server/cert_test.go
+++ b/internal/server/cert_test.go
@@ -56,6 +56,25 @@ func TestCachesLoadedCertificate(t *testing.T) {
 	require.Equal(t, cert1, cert2)
 }
 
+func TestErrorWhenFileDoesNotExist(t *testing.T) {
+	manager := NewStaticCertManager("testdata/cert.pem", "testdata/key.pem")
+	cert1, err := manager.GetCertificate(&tls.ClientHelloInfo{})
+	require.ErrorContains(t, err, "no such file or directory")
+	require.Nil(t, cert1)
+}
+
+func TestErrorWhenKeyFormatIsInvalid(t *testing.T) {
+	certPath, keyPath, err := prepareTestCertificateFiles()
+	require.NoError(t, err)
+	defer os.Remove(certPath)
+	defer os.Remove(keyPath)
+
+	manager := NewStaticCertManager(keyPath, certPath)
+	cert1, err := manager.GetCertificate(&tls.ClientHelloInfo{})
+	require.ErrorContains(t, err, "failed to find certificate PEM data in certificate input")
+	require.Nil(t, cert1)
+}
+
 func prepareTestCertificateFiles() (string, string, error) {
 	certFile, err := os.CreateTemp("", "example-cert-*.pem")
 	if err != nil {

--- a/internal/server/cert_test.go
+++ b/internal/server/cert_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"crypto/tls"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const certPem = `-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`
+
+const keyPem = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`
+
+func TestCertificateLoading(t *testing.T) {
+	certPath, keyPath, err := prepareTestCertificateFiles()
+	require.NoError(t, err)
+	defer os.Remove(certPath)
+	defer os.Remove(keyPath)
+
+	manager := NewStaticCertManager(certPath, keyPath)
+	cert, err := manager.GetCertificate(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+}
+
+func TestCachesLoadedCertificate(t *testing.T) {
+	certPath, keyPath, err := prepareTestCertificateFiles()
+	require.NoError(t, err)
+	defer os.Remove(certPath)
+	defer os.Remove(keyPath)
+
+	manager := NewStaticCertManager(certPath, keyPath)
+	cert1, err := manager.GetCertificate(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, cert1)
+
+	os.Remove(certPath)
+	os.Remove(keyPath)
+
+	cert2, err := manager.GetCertificate(&tls.ClientHelloInfo{})
+	require.Equal(t, cert1, cert2)
+}
+
+func prepareTestCertificateFiles() (string, string, error) {
+	certFile, err := os.CreateTemp("", "example-cert-*.pem")
+	if err != nil {
+		return "", "", err
+	}
+	defer certFile.Close()
+	certFile.Write([]byte(certPem))
+
+	keyFile, err := os.CreateTemp("", "example-key-*.pem")
+	if err != nil {
+		return "", "", err
+	}
+	defer keyFile.Close()
+	keyFile.Write([]byte(keyPem))
+
+	return certFile.Name(), keyFile.Name(), nil
+}

--- a/internal/server/cert_test.go
+++ b/internal/server/cert_test.go
@@ -38,6 +38,21 @@ func TestCertificateLoading(t *testing.T) {
 	require.NotNil(t, cert)
 }
 
+func TestCertificateLoadingRaceCondition(t *testing.T) {
+	certPath, keyPath, err := prepareTestCertificateFiles()
+	require.NoError(t, err)
+	defer os.Remove(certPath)
+	defer os.Remove(keyPath)
+
+	manager := NewStaticCertManager(certPath, keyPath)
+	go func() {
+		manager.GetCertificate(&tls.ClientHelloInfo{})
+	}()
+	cert, err := manager.GetCertificate(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+}
+
 func TestCachesLoadedCertificate(t *testing.T) {
 	certPath, keyPath, err := prepareTestCertificateFiles()
 	require.NoError(t, err)

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -42,6 +42,21 @@ func TestService_RedirectToHTTPWhenTLSRequired(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)
 }
 
+func TestService_UseStaticTLSCertificateWhenConfigured(t *testing.T) {
+	service := testCreateService(
+		t,
+		[]string{"example.com"},
+		ServiceOptions{
+			TLSEnabled:         true,
+			TLSCertificatePath: "cert.pem",
+			TLSPrivateKeyPath:  "key.pem",
+		},
+		defaultTargetOptions,
+	)
+
+	require.NotNil(t, service.certManager.(*StaticCertManager))
+}
+
 func TestService_RejectTLSRequestsWhenNotConfigured(t *testing.T) {
 	service := testCreateService(t, defaultEmptyHosts, defaultServiceOptions, defaultTargetOptions)
 

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -54,7 +54,7 @@ func TestService_UseStaticTLSCertificateWhenConfigured(t *testing.T) {
 		defaultTargetOptions,
 	)
 
-	require.NotNil(t, service.certManager.(*StaticCertManager))
+	require.IsType(t, &StaticCertManager{}, service.certManager)
 }
 
 func TestService_RejectTLSRequestsWhenNotConfigured(t *testing.T) {


### PR DESCRIPTION
In some cases it is needed to use a custom TLS certificate:

* For Cloudflare origin TLS
* In a corporate environment with custom certificate authority (CA)
* In a development environment with self-signed certificate
* In cloud development environment and end to end testing pipelines
* Some people still purchase certificates from "trusted vendor™"

With Traefic we had an option to specify a custom certificate, and so this change brings this feature into kamal-proxy.

~~PS. I am still looking into adding tests, wanted to gauge opinions whether this is a feature you are interested in.~~ 
_covered by tests now_

## Related kamal changes

* https://github.com/basecamp/kamal/pull/969
* https://github.com/basecamp/kamal-site/pull/100