### PR TITLE
Update CI actions to the latest version due to deprecated node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.23.x'
 


### PR DESCRIPTION
The `actions/checkout@v3` and `actions/setup-go@v4` use an deprecated Node.js version, causing a warning message to appear with each run. This PR updates these actions to the latest version, which utilizes Node.js 20 instead of 16.