### PR TITLE
Addressed a data race condition in the server tests

### DIFF
--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -236,14 +237,14 @@ func TestTarget_DrainWhenEmpty(t *testing.T) {
 
 func TestTarget_DrainRequestsThatCompleteWithinTimeout(t *testing.T) {
 	n := 3
-	served := 0
+	var served int32 = 0
 
 	var started sync.WaitGroup
 	started.Add(n)
 
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(time.Millisecond * 200)
-		served++
+		atomic.AddInt32(&served, 1)
 		started.Done()
 	})
 
@@ -256,7 +257,7 @@ func TestTarget_DrainRequestsThatCompleteWithinTimeout(t *testing.T) {
 	started.Wait()
 	target.Drain(time.Second * 5)
 
-	require.Equal(t, n, served)
+	require.Equal(t, int32(n), served)
 }
 
 func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {

--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -237,14 +237,14 @@ func TestTarget_DrainWhenEmpty(t *testing.T) {
 
 func TestTarget_DrainRequestsThatCompleteWithinTimeout(t *testing.T) {
 	n := 3
-	var served int32 = 0
+	var served atomic.Uint32
 
 	var started sync.WaitGroup
 	started.Add(n)
 
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(time.Millisecond * 200)
-		atomic.AddInt32(&served, 1)
+		served.Add(1)
 		started.Done()
 	})
 
@@ -257,7 +257,7 @@ func TestTarget_DrainRequestsThatCompleteWithinTimeout(t *testing.T) {
 	started.Wait()
 	target.Drain(time.Second * 5)
 
-	require.Equal(t, int32(n), served)
+	require.Equal(t, uint32(n), served.Load())
 }
 
 func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {


### PR DESCRIPTION
Addresses a data race in the server tests.

To reproduce:

```bash
go test ./... -race
```

Output before the change:

```
==================
WARNING: DATA RACE
Read at 0x00c000536398 by goroutine 589:
  github.com/basecamp/kamal-proxy/internal/server.TestTarget_DrainRequestsThatCompleteWithinTimeout.func1()
      /Users/dmytro/work/github/kamal-proxy/internal/server/target_test.go:246 +0x40
  net/http.HandlerFunc.ServeHTTP()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:2220 +0x48
  net/http.serverHandler.ServeHTTP()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:3210 +0x2a8
  net/http.(*conn).serve()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:2092 +0xe58
  net/http.(*Server).Serve.gowrap3()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:3360 +0x4c

Previous write at 0x00c000536398 by goroutine 590:
  github.com/basecamp/kamal-proxy/internal/server.TestTarget_DrainRequestsThatCompleteWithinTimeout.func1()
      /Users/dmytro/work/github/kamal-proxy/internal/server/target_test.go:246 +0x50
  net/http.HandlerFunc.ServeHTTP()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:2220 +0x48
  net/http.serverHandler.ServeHTTP()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:3210 +0x2a8
  net/http.(*conn).serve()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:2092 +0xe58
  net/http.(*Server).Serve.gowrap3()
      /Users/dmytro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.darwin-arm64/src/net/http/server.go:3360 +0x4c
```