### PR TITLE
Allow multiple hosts per service

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -64,7 +64,7 @@ func (c *deployCommand) run(cmd *cobra.Command, args []string) error {
 
 	if c.tls {
 		c.args.ServiceOptions.ACMECachePath = globalConfig.CertificatePath()
-		c.args.ServiceOptions.TLSHostname = c.args.Host
+		c.args.ServiceOptions.TLSHostnames = []string{c.args.Host}
 	}
 
 	if c.tlsStaging {

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -29,7 +29,7 @@ func newDeployCommand() *deployCommand {
 	}
 
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.TargetURL, "target", "", "Target host to deploy")
-	deployCommand.cmd.Flags().StringVar(&deployCommand.args.Host, "host", "", "Host to serve this target on (empty for wildcard)")
+	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.Hosts, "host", []string{}, "Host(s) to serve this target on (empty for wildcard)")
 
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tls, "tls", false, "Configure TLS for this target (requires a non-empty host)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
@@ -64,7 +64,7 @@ func (c *deployCommand) run(cmd *cobra.Command, args []string) error {
 
 	if c.tls {
 		c.args.ServiceOptions.ACMECachePath = globalConfig.CertificatePath()
-		c.args.ServiceOptions.TLSHostnames = []string{c.args.Host}
+		c.args.ServiceOptions.TLSHostnames = c.args.Hosts
 	}
 
 	if c.tlsStaging {

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -10,9 +10,8 @@ import (
 )
 
 type deployCommand struct {
-	cmd  *cobra.Command
-	args server.DeployArgs
-
+	cmd        *cobra.Command
+	args       server.DeployArgs
 	tlsStaging bool
 }
 

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -13,7 +13,6 @@ type deployCommand struct {
 	cmd  *cobra.Command
 	args server.DeployArgs
 
-	tls        bool
 	tlsStaging bool
 }
 
@@ -31,7 +30,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.TargetURL, "target", "", "Target host to deploy")
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.Hosts, "host", []string{}, "Host(s) to serve this target on (empty for wildcard)")
 
-	deployCommand.cmd.Flags().BoolVar(&deployCommand.tls, "tls", false, "Configure TLS for this target (requires a non-empty host)")
+	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSEnabled, "tls", false, "Configure TLS for this target (requires a non-empty host)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
 
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DeployTimeout, "deploy-timeout", server.DefaultDeployTimeout, "Maximum time to wait for the new target to become healthy")
@@ -62,13 +61,12 @@ func newDeployCommand() *deployCommand {
 func (c *deployCommand) run(cmd *cobra.Command, args []string) error {
 	c.args.Service = args[0]
 
-	if c.tls {
+	if c.args.ServiceOptions.TLSEnabled {
 		c.args.ServiceOptions.ACMECachePath = globalConfig.CertificatePath()
-		c.args.ServiceOptions.TLSHostnames = c.args.Hosts
-	}
 
-	if c.tlsStaging {
-		c.args.ServiceOptions.ACMEDirectory = server.ACMEStagingDirectoryURL
+		if c.tlsStaging {
+			c.args.ServiceOptions.ACMEDirectory = server.ACMEStagingDirectoryURL
+		}
 	}
 
 	return withRPCClient(globalConfig.SocketPath(), func(client *rpc.Client) error {
@@ -91,7 +89,7 @@ func (c *deployCommand) preRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if !cmd.Flags().Changed("forward-headers") {
-		c.args.TargetOptions.ForwardHeaders = !c.tls
+		c.args.TargetOptions.ForwardHeaders = !c.args.ServiceOptions.TLSEnabled
 	}
 
 	return nil

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -18,8 +18,8 @@ type CommandHandler struct {
 
 type DeployArgs struct {
 	Service        string
-	Host           string
 	TargetURL      string
+	Hosts          []string
 	DeployTimeout  time.Duration
 	DrainTimeout   time.Duration
 	ServiceOptions ServiceOptions
@@ -114,7 +114,7 @@ func (h *CommandHandler) Close() error {
 }
 
 func (h *CommandHandler) Deploy(args DeployArgs, reply *bool) error {
-	return h.router.SetServiceTarget(args.Service, args.Host, args.TargetURL, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
+	return h.router.SetServiceTarget(args.Service, args.Hosts, args.TargetURL, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
 }
 
 func (h *CommandHandler) Pause(args PauseArgs, reply *bool) error {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -121,7 +121,7 @@ func (r *Router) SetServiceTarget(name string, hosts []string, targetURL string,
 ) error {
 	defer r.saveStateSnapshot()
 
-	slog.Info("Deploying", "service", name, "hosts", hosts, "target", targetURL, "tls", options.RequireTLS())
+	slog.Info("Deploying", "service", name, "hosts", hosts, "target", targetURL, "tls", options.TLSEnabled)
 
 	target, err := NewTarget(targetURL, targetOptions)
 	if err != nil {
@@ -261,7 +261,7 @@ func (r *Router) ListActiveServices() ServiceDescriptionMap {
 				result[name] = ServiceDescription{
 					Host:   host,
 					Target: service.active.Target(),
-					TLS:    service.options.RequireTLS(),
+					TLS:    service.options.TLSEnabled,
 					State:  service.pauseController.GetState().String(),
 				}
 			}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -16,7 +16,7 @@ import (
 var (
 	ErrorServiceNotFound             = errors.New("service not found")
 	ErrorTargetFailedToBecomeHealthy = errors.New("target failed to become healthy")
-	ErrorHostInUse                   = errors.New("host is used by another service")
+	ErrorHostInUse                   = errors.New("host settings conflict with another service")
 	ErrorNoServerName                = errors.New("no server name provided")
 	ErrorUnknownServerName           = errors.New("unknown server name")
 )
@@ -39,6 +39,10 @@ func (m ServiceMap) HostServices() HostServiceMap {
 }
 
 func (m HostServiceMap) CheckHostAvailability(name string, hosts []string) *Service {
+	if len(hosts) == 0 {
+		hosts = []string{""}
+	}
+
 	for _, host := range hosts {
 		service := m[host]
 		if service != nil && service.name != name {
@@ -346,7 +350,7 @@ func (r *Router) setActiveTarget(name string, hosts []string, target *Target, op
 
 	conflict := r.hostServices.CheckHostAvailability(name, hosts)
 	if conflict != nil {
-		slog.Error("Host in use by another service", "service", conflict.name)
+		slog.Error("Host settings conflict with another service", "service", conflict.name)
 		return ErrorHostInUse
 	}
 

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -124,7 +124,7 @@ func TestRouter_UpdatingOptions(t *testing.T) {
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	serviceOptions.TLSHostname = "dummy.example.com"
+	serviceOptions.TLSHostnames = []string{"dummy.example.com"}
 	require.NoError(t, router.SetServiceTarget("service1", "dummy.example.com", target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -296,15 +296,14 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 
 	router := NewRouter(statePath)
 	require.NoError(t, router.SetServiceTarget("default", []string{""}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("other", []string{"other.example.com"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("other", []string{"other.example.com"}, second, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://something.example.com")
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	statusCode, body = sendGETRequest(router, "http://other.example.com/")
-	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Equal(t, "second", body)
+	statusCode, _ = sendGETRequest(router, "http://other.example.com/")
+	assert.Equal(t, http.StatusMovedPermanently, statusCode)
 
 	router = NewRouter(statePath)
 	router.RestoreLastSavedState()
@@ -313,9 +312,8 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	statusCode, body = sendGETRequest(router, "http://other.example.com/")
-	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Equal(t, "second", body)
+	statusCode, _ = sendGETRequest(router, "http://other.example.com/")
+	assert.Equal(t, http.StatusMovedPermanently, statusCode)
 }
 
 // Helpers

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -36,7 +36,7 @@ func TestRouter_Removing(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", "dummy.example.com", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -142,7 +142,7 @@ func TestRouter_UpdatingOptions(t *testing.T) {
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	serviceOptions.TLSHostnames = []string{"dummy.example.com"}
+	serviceOptions.TLSEnabled = true
 	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -112,7 +112,7 @@ func TestRouter_ActiveServiceWithoutHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{""}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
@@ -268,7 +268,7 @@ func TestRouter_TargetWithoutHostActsAsWildcard(t *testing.T) {
 	_, second := testBackend(t, "second", http.StatusOK)
 
 	require.NoError(t, router.SetServiceTarget("service1", []string{"s1.example.com"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("default", []string{""}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://s1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -300,7 +300,7 @@ func TestRouter_EnablingRollout(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{""}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	require.NoError(t, router.SetRolloutTarget("service1", second, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	checkResponse := func(expected string) {
@@ -330,7 +330,7 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 	_, second := testBackend(t, "second", http.StatusOK)
 
 	router := NewRouter(statePath)
-	require.NoError(t, router.SetServiceTarget("default", []string{""}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	require.NoError(t, router.SetServiceTarget("other", []string{"other.example.com"}, second, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://something.example.com")

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -47,6 +47,24 @@ func TestRouter_Removing(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, statusCode)
 }
 
+func TestRouter_ActiveServiceForMultipleHosts(t *testing.T) {
+	router := testRouter(t)
+	_, target := testBackend(t, "first", http.StatusOK)
+
+	require.NoError(t, router.SetServiceTarget("service1", []string{"1.example.com", "2.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+
+	statusCode, body := sendGETRequest(router, "http://1.example.com/")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "first", body)
+
+	statusCode, body = sendGETRequest(router, "http://2.example.com/")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "first", body)
+
+	statusCode, _ = sendGETRequest(router, "http://3.example.com/")
+	assert.Equal(t, http.StatusNotFound, statusCode)
+}
+
 func TestRouter_ActiveServiceForUnknownHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -85,7 +85,7 @@ func (so ServiceOptions) ScopedCachePath() string {
 
 type Service struct {
 	name    string
-	host    string
+	hosts   []string
 	options ServiceOptions
 
 	active     *Target
@@ -98,10 +98,10 @@ type Service struct {
 	middleware        http.Handler
 }
 
-func NewService(name, host string, options ServiceOptions) *Service {
+func NewService(name string, hosts []string, options ServiceOptions) *Service {
 	service := &Service{
 		name:    name,
-		host:    host,
+		hosts:   hosts,
 		options: options,
 	}
 
@@ -110,8 +110,8 @@ func NewService(name, host string, options ServiceOptions) *Service {
 	return service
 }
 
-func (s *Service) UpdateOptions(host string, options ServiceOptions) {
-	s.host = host
+func (s *Service) UpdateOptions(hosts []string, options ServiceOptions) {
+	s.hosts = hosts
 	s.options = options
 	s.certManager = s.createCertManager()
 	s.middleware = s.createMiddleware()
@@ -195,7 +195,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type marshalledService struct {
 	Name              string             `json:"name"`
-	Host              string             `json:"host"`
+	Hosts             []string           `json:"hosts"`
 	ActiveTarget      string             `json:"active_target"`
 	RolloutTarget     string             `json:"rollout_target"`
 	Options           ServiceOptions     `json:"options"`
@@ -214,7 +214,7 @@ func (s *Service) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(marshalledService{
 		Name:              s.name,
-		Host:              s.host,
+		Hosts:             s.hosts,
 		ActiveTarget:      activeTarget,
 		RolloutTarget:     rolloutTarget,
 		Options:           s.options,
@@ -232,7 +232,7 @@ func (s *Service) UnmarshalJSON(data []byte) error {
 	}
 
 	s.name = ms.Name
-	s.host = ms.Host
+	s.hosts = ms.Hosts
 	s.options = ms.Options
 	s.initialize()
 

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -110,7 +110,8 @@ func NewService(name, host string, options ServiceOptions) *Service {
 	return service
 }
 
-func (s *Service) UpdateOptions(options ServiceOptions) {
+func (s *Service) UpdateOptions(host string, options ServiceOptions) {
+	s.host = host
 	s.options = options
 	s.certManager = s.createCertManager()
 	s.middleware = s.createMiddleware()

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -60,14 +60,14 @@ type HealthCheckConfig struct {
 }
 
 type ServiceOptions struct {
-	TLSHostname   string `json:"tls_hostname"`
-	ACMEDirectory string `json:"acme_directory"`
-	ACMECachePath string `json:"acme_cache_path"`
-	ErrorPagePath string `json:"error_page_path"`
+	TLSHostnames  []string `json:"tls_hostnames"`
+	ACMEDirectory string   `json:"acme_directory"`
+	ACMECachePath string   `json:"acme_cache_path"`
+	ErrorPagePath string   `json:"error_page_path"`
 }
 
 func (so ServiceOptions) RequireTLS() bool {
-	return so.TLSHostname != ""
+	return len(so.TLSHostnames) > 0
 }
 
 func (so ServiceOptions) ScopedCachePath() string {
@@ -289,14 +289,14 @@ func (s *Service) initialize() {
 }
 
 func (s *Service) createCertManager() *autocert.Manager {
-	if s.options.TLSHostname == "" {
+	if !s.options.RequireTLS() {
 		return nil
 	}
 
 	return &autocert.Manager{
 		Prompt:     autocert.AcceptTOS,
 		Cache:      autocert.DirCache(s.options.ScopedCachePath()),
-		HostPolicy: autocert.HostWhitelist(s.options.TLSHostname),
+		HostPolicy: autocert.HostWhitelist(s.options.TLSHostnames...),
 		Client:     &acme.Client{DirectoryURL: s.options.ACMEDirectory},
 	}
 }

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -127,7 +127,7 @@ func testCreateService(t *testing.T, options ServiceOptions, targetOptions Targe
 	target, err := NewTarget(serverURL.Host, targetOptions)
 	require.NoError(t, err)
 
-	service := NewService("test", "", options)
+	service := NewService("test", []string{""}, options)
 	service.active = target
 
 	return service

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -25,7 +25,7 @@ func TestService_ServeRequest(t *testing.T) {
 }
 
 func TestService_RedirectToHTTPWhenTLSRequired(t *testing.T) {
-	service := testCreateService(t, ServiceOptions{TLSHostname: "example.com"}, defaultTargetOptions)
+	service := testCreateService(t, ServiceOptions{TLSHostnames: []string{"example.com"}}, defaultTargetOptions)
 
 	require.True(t, service.options.RequireTLS())
 

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	defaultHealthCheckConfig = HealthCheckConfig{Path: DefaultHealthCheckPath, Interval: DefaultHealthCheckInterval, Timeout: DefaultHealthCheckTimeout}
+	defaultEmptyHosts        = []string{}
 	defaultServiceOptions    = ServiceOptions{}
 	defaultTargetOptions     = TargetOptions{HealthCheckConfig: defaultHealthCheckConfig, ResponseTimeout: DefaultTargetTimeout}
 )


### PR DESCRIPTION
This adds the ability to associate multiple hostnames with a single service. For example:

    kamal-proxy deploy myapp --target=web-1 --host=app.example.com,api.example.com

You can use a comma-delimited list in the `host` flag, and/or specify the flag multiple times.

When a service has multiple hostnames, requests to any of those hostnames will route to the service. If the service also specifies `--tls`, then all of the host names will be covered in the TLS certificates.

Closes #14.