### PR TITLE
Add ACME HTTP-01 Challenge support

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -86,7 +86,7 @@ func (s *Server) startHTTPServers() error {
 	s.httpListener = l
 	s.httpServer = &http.Server{
 		Addr:    httpAddr,
-		Handler: handler,
+		Handler: s.router.WithHttp01Challenge(handler),
 	}
 
 	l, err = net.Listen("tcp", httpsAddr)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestServer_Deploying(t *testing.T) {
-	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {})
+	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 	server, addr := testServer(t)
 
 	testDeployTarget(t, target, server)


### PR DESCRIPTION
For #26, make the HTTP-01 challenge supported.

### TBD

* Should we make the `HTTP-01` optional (disabled by default)
* Should we create `HTTP-01` middleware when path start with `/.well-known/acme-challenge/` or create it for all request
* Let's try to make a mock ACME server to test it