### PR TITLE
Don't buffer SSE responses

### DIFF
--- a/internal/server/logging_middleware.go
+++ b/internal/server/logging_middleware.go
@@ -151,3 +151,10 @@ func (r *loggerResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 	return con, rw, err
 }
+
+func (r *loggerResponseWriter) Flush() {
+	flusher, ok := r.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}

--- a/internal/server/response_buffer_middleware.go
+++ b/internal/server/response_buffer_middleware.go
@@ -95,3 +95,10 @@ func (w *bufferedResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 	return nil, nil, http.ErrNotSupported
 }
+
+func (w *bufferedResponseWriter) Flush() {
+	flusher, ok := w.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}

--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -386,3 +386,10 @@ func (r *targetResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	r.inflightRequest.hijacked = true
 	return hijacker.Hijack()
 }
+
+func (r *targetResponseWriter) Flush() {
+	flusher, ok := r.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}


### PR DESCRIPTION
SSE requires being able to flush the response stream as each message is written. Response buffering gets in the way of this -- the messages will be flushed into the buffer, but the client won't see any of them until the response is closed.

To support SSE while allowing the use of response buffering elsewhere, we can add a bypass for responses that have `Content-Type: text/event-stream` that prevents them being buffered.

We'll also need to make sure that any custom `ResponseWriter`s in the handler are `Flush`-able.

Fixes #34.