### PR TITLE
Add concurrency to tests with `t.Parallel()`

### DIFF
--- a/internal/server/buffer_test.go
+++ b/internal/server/buffer_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestBufferedReadCloser(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		maxBytes       int64
 		maxMemBytes    int64
@@ -24,6 +26,7 @@ func TestBufferedReadCloser(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			r := io.NopCloser(strings.NewReader("Hello, World!"))
 			brc, err := NewBufferedReadCloser(r, tc.maxBytes, tc.maxMemBytes)
 
@@ -41,6 +44,7 @@ func TestBufferedReadCloser(t *testing.T) {
 }
 
 func TestBufferedReadCloser_EmptyReader(t *testing.T) {
+	t.Parallel()
 	r := io.NopCloser(strings.NewReader(""))
 	brc, err := NewBufferedReadCloser(r, 2048, 1024)
 
@@ -52,6 +56,8 @@ func TestBufferedReadCloser_EmptyReader(t *testing.T) {
 }
 
 func TestBufferedWriteCloser(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		maxBytes       int64
 		maxMemBytes    int64
@@ -66,6 +72,7 @@ func TestBufferedWriteCloser(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			bwc := NewBufferedWriteCloser(tc.maxBytes, tc.maxMemBytes)
 			_, err := bwc.Write([]byte("Hello, World!"))
 
@@ -84,6 +91,7 @@ func TestBufferedWriteCloser(t *testing.T) {
 }
 
 func TestBufferedWriteCloser_NothingWritten(t *testing.T) {
+	t.Parallel()
 	bwc := NewBufferedWriteCloser(2048, 1024)
 
 	var result strings.Builder

--- a/internal/server/cert_test.go
+++ b/internal/server/cert_test.go
@@ -29,6 +29,7 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 -----END EC PRIVATE KEY-----`
 
 func TestCertificateLoading(t *testing.T) {
+	t.Parallel()
 	certPath, keyPath := prepareTestCertificateFiles(t)
 
 	manager, err := NewStaticCertManager(certPath, keyPath)
@@ -42,11 +43,13 @@ func TestCertificateLoading(t *testing.T) {
 }
 
 func TestErrorWhenFileDoesNotExist(t *testing.T) {
+	t.Parallel()
 	_, err := NewStaticCertManager("testdata/cert.pem", "testdata/key.pem")
 	require.ErrorContains(t, err, "unable to load certificate")
 }
 
 func TestErrorWhenKeyFormatIsInvalid(t *testing.T) {
+	t.Parallel()
 	certPath, keyPath := prepareTestCertificateFiles(t)
 
 	_, err := NewStaticCertManager(keyPath, certPath) // swapped paths

--- a/internal/server/error_page_middleware_test.go
+++ b/internal/server/error_page_middleware_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestErrorPageMiddleware(t *testing.T) {
+	t.Parallel()
+
 	check := func(handler http.HandlerFunc) (int, string, string) {
 		middleware, err := WithErrorPageMiddleware(pages.DefaultErrorPages, true, handler)
 		require.NoError(t, err)
@@ -27,6 +29,8 @@ func TestErrorPageMiddleware(t *testing.T) {
 	}
 
 	t.Run("when setting a custom error response", func(t *testing.T) {
+		t.Parallel()
+
 		status, contentType, body := check(func(w http.ResponseWriter, r *http.Request) {
 			SetErrorResponse(w, r, http.StatusNotFound, nil)
 		})
@@ -37,6 +41,8 @@ func TestErrorPageMiddleware(t *testing.T) {
 	})
 
 	t.Run("when including template arguments in a custom error response", func(t *testing.T) {
+		t.Parallel()
+
 		status, contentType, body := check(func(w http.ResponseWriter, r *http.Request) {
 			SetErrorResponse(w, r, http.StatusServiceUnavailable, struct{ Message string }{"Gone to lunch"})
 		})
@@ -48,6 +54,8 @@ func TestErrorPageMiddleware(t *testing.T) {
 	})
 
 	t.Run("when trying to set an error that we don't have a template for", func(t *testing.T) {
+		t.Parallel()
+
 		status, contentType, body := check(func(w http.ResponseWriter, r *http.Request) {
 			SetErrorResponse(w, r, http.StatusTeapot, nil)
 		})
@@ -58,6 +66,8 @@ func TestErrorPageMiddleware(t *testing.T) {
 	})
 
 	t.Run("when the backend returns an error normally", func(t *testing.T) {
+		t.Parallel()
+
 		status, contentType, body := check(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, http.StatusText(http.StatusTeapot), http.StatusTeapot)
 		})
@@ -69,6 +79,8 @@ func TestErrorPageMiddleware(t *testing.T) {
 }
 
 func TestErrorPageMiddleware_Nesting(t *testing.T) {
+	t.Parallel()
+
 	check := func(handler http.HandlerFunc) (int, string, string) {
 		customPages := fstest.MapFS(map[string]*fstest.MapFile{
 			"404.html": {Data: []byte("<body>Custom 404</body>")},
@@ -86,6 +98,8 @@ func TestErrorPageMiddleware_Nesting(t *testing.T) {
 	}
 
 	t.Run("with an error in the inner FS", func(t *testing.T) {
+		t.Parallel()
+
 		status, contentType, body := check(func(w http.ResponseWriter, r *http.Request) {
 			SetErrorResponse(w, r, http.StatusNotFound, nil)
 		})
@@ -96,6 +110,8 @@ func TestErrorPageMiddleware_Nesting(t *testing.T) {
 	})
 
 	t.Run("with an error not in the inner FS", func(t *testing.T) {
+		t.Parallel()
+
 		status, contentType, body := check(func(w http.ResponseWriter, r *http.Request) {
 			SetErrorResponse(w, r, http.StatusServiceUnavailable, struct{ Message string }{"Gone to lunch"})
 		})
@@ -107,6 +123,8 @@ func TestErrorPageMiddleware_Nesting(t *testing.T) {
 	})
 
 	t.Run("with an error not in any FS", func(t *testing.T) {
+		t.Parallel()
+
 		status, contentType, body := check(func(w http.ResponseWriter, r *http.Request) {
 			SetErrorResponse(w, r, http.StatusTeapot, nil)
 		})
@@ -118,6 +136,8 @@ func TestErrorPageMiddleware_Nesting(t *testing.T) {
 }
 
 func TestErrorPageMiddleware_WithInvalidArguments(t *testing.T) {
+	t.Parallel()
+
 	ensureFailed := func(pages fs.FS) {
 		handler := func(w http.ResponseWriter, r *http.Request) {}
 		_, err := WithErrorPageMiddleware(pages, false, http.HandlerFunc(handler))
@@ -126,6 +146,8 @@ func TestErrorPageMiddleware_WithInvalidArguments(t *testing.T) {
 	}
 
 	t.Run("with templates that cannot be compiled", func(t *testing.T) {
+		t.Parallel()
+
 		pages := fstest.MapFS(map[string]*fstest.MapFile{
 			"404.html": {Data: []byte("<body>{{ {{</body>")},
 		})
@@ -133,6 +155,8 @@ func TestErrorPageMiddleware_WithInvalidArguments(t *testing.T) {
 	})
 
 	t.Run("with a filesystem that has no templates", func(t *testing.T) {
+		t.Parallel()
+
 		pages := fstest.MapFS(map[string]*fstest.MapFile{})
 		ensureFailed(pages)
 	})

--- a/internal/server/logging_middleware_test.go
+++ b/internal/server/logging_middleware_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestMiddleware_LoggingMiddleware(t *testing.T) {
+	t.Parallel()
 	out := &strings.Builder{}
 	logger := slog.New(slog.NewJSONHandler(out, nil))
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/pause_controller_test.go
+++ b/internal/server/pause_controller_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPauseController_RunningByDefault(t *testing.T) {
+	t.Parallel()
+
 	p := NewPauseController()
 
 	assert.Equal(t, PauseStateRunning, p.GetState())
@@ -19,6 +21,8 @@ func TestPauseController_RunningByDefault(t *testing.T) {
 }
 
 func TestPauseController_WaitBlocksWhenPaused(t *testing.T) {
+	t.Parallel()
+
 	p := NewPauseController()
 	var wg sync.WaitGroup
 
@@ -38,6 +42,8 @@ func TestPauseController_WaitBlocksWhenPaused(t *testing.T) {
 }
 
 func TestPauseController_PausedWaitsCanTimeout(t *testing.T) {
+	t.Parallel()
+
 	p := NewPauseController()
 
 	require.NoError(t, p.Pause(time.Millisecond))
@@ -49,6 +55,8 @@ func TestPauseController_PausedWaitsCanTimeout(t *testing.T) {
 }
 
 func TestPauseController_Stopped(t *testing.T) {
+	t.Parallel()
+
 	p := NewPauseController()
 
 	require.NoError(t, p.Stop(DefaultStopMessage))
@@ -60,6 +68,8 @@ func TestPauseController_Stopped(t *testing.T) {
 }
 
 func TestPauseController_StoppingPausedRequestsFailsThemImmediately(t *testing.T) {
+	t.Parallel()
+
 	p := NewPauseController()
 	var wg sync.WaitGroup
 

--- a/internal/server/request_buffer_middleware_test.go
+++ b/internal/server/request_buffer_middleware_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestRequestBufferMiddleware(t *testing.T) {
+	t.Parallel()
+
 	sendRequest := func(requestBody, responseBody string) *httptest.ResponseRecorder {
 		middleware := WithRequestBufferMiddleware(4, 8, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(responseBody))
@@ -23,6 +25,8 @@ func TestRequestBufferMiddleware(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
 		w := sendRequest("hello", "ok")
 
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -30,6 +34,8 @@ func TestRequestBufferMiddleware(t *testing.T) {
 	})
 
 	t.Run("request body too large", func(t *testing.T) {
+		t.Parallel()
+
 		w := sendRequest("this request body is much too large", "ok")
 
 		assert.Equal(t, http.StatusRequestEntityTooLarge, w.Result().StatusCode)

--- a/internal/server/request_id_middleware_test.go
+++ b/internal/server/request_id_middleware_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestRequestIDMiddleware_AddsAnIDWhenNotPresent(t *testing.T) {
+	t.Parallel()
+
 	handler := WithRequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.Header.Get("X-Request-ID")
 		assert.NotEmpty(t, id)
@@ -22,6 +24,8 @@ func TestRequestIDMiddleware_AddsAnIDWhenNotPresent(t *testing.T) {
 }
 
 func TestRequestIDMiddleware_PreservesExistingHeaderWhenPresent(t *testing.T) {
+	t.Parallel()
+
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.Header.Get("X-Request-ID")
 		assert.Equal(t, "1234", id)

--- a/internal/server/response_buffer_middleware_test.go
+++ b/internal/server/response_buffer_middleware_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestResponseBufferMiddleware(t *testing.T) {
+	t.Parallel()
+
 	sendRequest := func(requestBody, responseBody string) *httptest.ResponseRecorder {
 		middleware := WithResponseBufferMiddleware(4, 8, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(responseBody))
@@ -23,6 +25,8 @@ func TestResponseBufferMiddleware(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
 		w := sendRequest("hello", "ok")
 
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -30,6 +34,8 @@ func TestResponseBufferMiddleware(t *testing.T) {
 	})
 
 	t.Run("response body too large", func(t *testing.T) {
+		t.Parallel()
+
 		w := sendRequest("hello", "this response body is much too large")
 
 		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)

--- a/internal/server/rollout_controller_test.go
+++ b/internal/server/rollout_controller_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestRolloutController_MatchesAllowlistItems(t *testing.T) {
+	t.Parallel()
+
 	rc := NewRolloutController(0, []string{"1", "2"})
 
 	assert.True(t, rc.RequestUsesRolloutGroup(&http.Request{Header: http.Header{"Cookie": []string{"kamal-rollout=1"}}}))
@@ -19,6 +21,8 @@ func TestRolloutController_MatchesAllowlistItems(t *testing.T) {
 }
 
 func TestRolloutController_PercentageSplit(t *testing.T) {
+	t.Parallel()
+
 	rc := NewRolloutController(60, []string{})
 
 	usedRolloutGroup := 0
@@ -35,6 +39,8 @@ func TestRolloutController_PercentageSplit(t *testing.T) {
 }
 
 func TestRolloutController_AllowListAndPercentageTogether(t *testing.T) {
+	t.Parallel()
+
 	rc := NewRolloutController(10, []string{"00001", "00002"})
 
 	usedRolloutGroup := 0

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRouter_Empty(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 
 	statusCode, _ := sendGETRequest(router, "http://example.com/")
@@ -21,6 +23,8 @@ func TestRouter_Empty(t *testing.T) {
 }
 
 func TestRouter_ActiveServiceForHost(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -33,6 +37,8 @@ func TestRouter_ActiveServiceForHost(t *testing.T) {
 }
 
 func TestRouter_Removing(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -48,6 +54,8 @@ func TestRouter_Removing(t *testing.T) {
 }
 
 func TestRouter_ActiveServiceForMultipleHosts(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -66,6 +74,8 @@ func TestRouter_ActiveServiceForMultipleHosts(t *testing.T) {
 }
 
 func TestRouter_UpdatingHostsOfActiveService(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -86,6 +96,8 @@ func TestRouter_UpdatingHostsOfActiveService(t *testing.T) {
 }
 
 func TestRouter_ActiveServiceForUnknownHost(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -97,6 +109,8 @@ func TestRouter_ActiveServiceForUnknownHost(t *testing.T) {
 }
 
 func TestRouter_ActiveServiceForHostContainingPort(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -109,6 +123,8 @@ func TestRouter_ActiveServiceForHostContainingPort(t *testing.T) {
 }
 
 func TestRouter_ActiveServiceWithoutHost(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -121,6 +137,8 @@ func TestRouter_ActiveServiceWithoutHost(t *testing.T) {
 }
 
 func TestRouter_ReplacingActiveService(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
@@ -141,6 +159,8 @@ func TestRouter_ReplacingActiveService(t *testing.T) {
 }
 
 func TestRouter_UpdatingOptions(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -171,6 +191,8 @@ func TestRouter_UpdatingOptions(t *testing.T) {
 }
 
 func TestRouter_DeploymmentsWithErrorsDoNotUpdateService(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -184,6 +206,8 @@ func TestRouter_DeploymmentsWithErrorsDoNotUpdateService(t *testing.T) {
 	ensureServiceIsHealthy()
 
 	t.Run("custom TLS that is not valid", func(t *testing.T) {
+		t.Parallel()
+
 		serviceOptions := ServiceOptions{TLSEnabled: true, TLSCertificatePath: "not valid", TLSPrivateKeyPath: "not valid"}
 		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
@@ -191,6 +215,8 @@ func TestRouter_DeploymmentsWithErrorsDoNotUpdateService(t *testing.T) {
 	})
 
 	t.Run("custom error pages that are not valid", func(t *testing.T) {
+		t.Parallel()
+
 		serviceOptions := ServiceOptions{ErrorPagePath: "not valid"}
 		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
@@ -199,6 +225,8 @@ func TestRouter_DeploymmentsWithErrorsDoNotUpdateService(t *testing.T) {
 }
 
 func TestRouter_UpdatingPauseStateIndependentlyOfDeployments(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
@@ -220,6 +248,8 @@ func TestRouter_UpdatingPauseStateIndependentlyOfDeployments(t *testing.T) {
 }
 
 func TestRouter_ChangingHostForService(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
@@ -243,6 +273,8 @@ func TestRouter_ChangingHostForService(t *testing.T) {
 }
 
 func TestRouter_ReusingHost(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
@@ -259,6 +291,8 @@ func TestRouter_ReusingHost(t *testing.T) {
 }
 
 func TestRouter_ReusingEmptyHost(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
@@ -274,6 +308,8 @@ func TestRouter_ReusingEmptyHost(t *testing.T) {
 }
 
 func TestRouter_RoutingMultipleHosts(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
@@ -291,6 +327,8 @@ func TestRouter_RoutingMultipleHosts(t *testing.T) {
 }
 
 func TestRouter_TargetWithoutHostActsAsWildcard(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
@@ -343,6 +381,8 @@ func TestRouter_WildcardDomainsCannotBeUsedWithAutomaticTLS(t *testing.T) {
 }
 
 func TestRouter_ServiceFailingToBecomeHealthy(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, target := testBackend(t, "", http.StatusInternalServerError)
 
@@ -355,6 +395,8 @@ func TestRouter_ServiceFailingToBecomeHealthy(t *testing.T) {
 }
 
 func TestRouter_EnablingRollout(t *testing.T) {
+	t.Parallel()
+
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
@@ -383,6 +425,8 @@ func TestRouter_EnablingRollout(t *testing.T) {
 }
 
 func TestRouter_RestoreLastSavedState(t *testing.T) {
+	t.Parallel()
+
 	statePath := filepath.Join(t.TempDir(), "state.json")
 
 	_, first := testBackend(t, "first", http.StatusOK)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestServer_Deploying(t *testing.T) {
+	t.Parallel()
+
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {})
 	server, addr := testServer(t)
 

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestService_ServeRequest(t *testing.T) {
+	t.Parallel()
+
 	service := testCreateService(t, defaultEmptyHosts, defaultServiceOptions, defaultTargetOptions)
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/", strings.NewReader(""))
@@ -25,6 +27,8 @@ func TestService_ServeRequest(t *testing.T) {
 }
 
 func TestService_RedirectToHTTPWhenTLSRequired(t *testing.T) {
+	t.Parallel()
+
 	service := testCreateService(t, []string{"example.com"}, ServiceOptions{TLSEnabled: true}, defaultTargetOptions)
 
 	require.True(t, service.options.TLSEnabled)
@@ -43,6 +47,8 @@ func TestService_RedirectToHTTPWhenTLSRequired(t *testing.T) {
 }
 
 func TestService_UseStaticTLSCertificateWhenConfigured(t *testing.T) {
+	t.Parallel()
+
 	certPath, keyPath := prepareTestCertificateFiles(t)
 
 	service := testCreateService(
@@ -60,6 +66,8 @@ func TestService_UseStaticTLSCertificateWhenConfigured(t *testing.T) {
 }
 
 func TestService_RejectTLSRequestsWhenNotConfigured(t *testing.T) {
+	t.Parallel()
+
 	service := testCreateService(t, defaultEmptyHosts, defaultServiceOptions, defaultTargetOptions)
 
 	require.False(t, service.options.TLSEnabled)
@@ -78,6 +86,8 @@ func TestService_RejectTLSRequestsWhenNotConfigured(t *testing.T) {
 }
 
 func TestService_ReturnSuccessfulHealthCheckWhilePausedOrStopped(t *testing.T) {
+	t.Parallel()
+
 	service := testCreateService(t, defaultEmptyHosts, defaultServiceOptions, defaultTargetOptions)
 
 	checkRequest := func(path string) int {
@@ -104,6 +114,8 @@ func TestService_ReturnSuccessfulHealthCheckWhilePausedOrStopped(t *testing.T) {
 }
 
 func TestService_MarshallingState(t *testing.T) {
+	t.Parallel()
+
 	targetOptions := TargetOptions{
 		HealthCheckConfig:   HealthCheckConfig{Path: "/health", Interval: 1, Timeout: 2},
 		BufferRequests:      true,

--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestTarget_Serve(t *testing.T) {
+	t.Parallel()
+
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
 	})
@@ -89,6 +91,8 @@ func TestTarget_ServeSSE(t *testing.T) {
 }
 
 func TestTarget_ServeWebSocket(t *testing.T) {
+	t.Parallel()
+
 	sendWebsocketMessage := func(bufferRequests, bufferResponses bool, body string) (websocket.MessageType, []byte, error) {
 		targetOptions := TargetOptions{
 			BufferRequests:      bufferRequests,
@@ -132,6 +136,8 @@ func TestTarget_ServeWebSocket(t *testing.T) {
 	}
 
 	t.Run("without buffering", func(t *testing.T) {
+		t.Parallel()
+
 		kind, body, err := sendWebsocketMessage(false, false, "hello")
 		require.NoError(t, err)
 		assert.Equal(t, websocket.MessageText, kind)
@@ -139,6 +145,8 @@ func TestTarget_ServeWebSocket(t *testing.T) {
 	})
 
 	t.Run("with buffering", func(t *testing.T) {
+		t.Parallel()
+
 		kind, body, err := sendWebsocketMessage(true, true, "world")
 		require.NoError(t, err)
 		assert.Equal(t, websocket.MessageText, kind)
@@ -147,6 +155,8 @@ func TestTarget_ServeWebSocket(t *testing.T) {
 }
 
 func TestTarget_PreserveTargetHeader(t *testing.T) {
+	t.Parallel()
+
 	var requestTarget string
 
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
@@ -163,6 +173,8 @@ func TestTarget_PreserveTargetHeader(t *testing.T) {
 }
 
 func TestTarget_XForwardedHeadersPopulatedByDefault(t *testing.T) {
+	t.Parallel()
+
 	var (
 		xForwardedFor   string
 		xForwardedProto string
@@ -202,6 +214,8 @@ func TestTarget_XForwardedHeadersPopulatedByDefault(t *testing.T) {
 }
 
 func TestTarget_XForwardedHeadersCanBeForwarded(t *testing.T) {
+	t.Parallel()
+
 	var (
 		xForwardedFor   string
 		xForwardedProto string
@@ -248,6 +262,8 @@ func TestTarget_XForwardedHeadersCanBeForwarded(t *testing.T) {
 }
 
 func TestTarget_UnparseableQueryParametersArePreserved(t *testing.T) {
+	t.Parallel()
+
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "p1=a;b;c&p2=%x&p3=ok", r.URL.RawQuery)
 	})
@@ -260,6 +276,8 @@ func TestTarget_UnparseableQueryParametersArePreserved(t *testing.T) {
 }
 
 func TestTarget_IsHealthCheckRequest(t *testing.T) {
+	t.Parallel()
+
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {})
 
 	assert.True(t, target.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up", nil)))
@@ -270,6 +288,8 @@ func TestTarget_IsHealthCheckRequest(t *testing.T) {
 }
 
 func TestTarget_AddedTargetBecomesHealthy(t *testing.T) {
+	t.Parallel()
+
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
 	})
@@ -288,12 +308,16 @@ func TestTarget_AddedTargetBecomesHealthy(t *testing.T) {
 }
 
 func TestTarget_DrainWhenEmpty(t *testing.T) {
+	t.Parallel()
+
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {})
 
 	target.Drain(time.Second)
 }
 
 func TestTarget_DrainRequestsThatCompleteWithinTimeout(t *testing.T) {
+	t.Parallel()
+
 	n := 3
 	var served atomic.Uint32
 
@@ -319,6 +343,8 @@ func TestTarget_DrainRequestsThatCompleteWithinTimeout(t *testing.T) {
 }
 
 func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {
+	t.Parallel()
+
 	n := 20
 	served := 0
 
@@ -349,6 +375,8 @@ func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {
 }
 
 func TestTarget_DrainHijackedConnectionsImmediately(t *testing.T) {
+	t.Parallel()
+
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
 		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{})
 		require.NoError(t, err)
@@ -377,6 +405,8 @@ func TestTarget_DrainHijackedConnectionsImmediately(t *testing.T) {
 }
 
 func TestTarget_EnforceMaxBodySizes(t *testing.T) {
+	t.Parallel()
+
 	sendRequest := func(bufferRequests, bufferResponses bool, maxMemorySize, maxBodySize int64, requestBody, responseBody string) *httptest.ResponseRecorder {
 		targetOptions := TargetOptions{
 			BufferRequests:      bufferRequests,
@@ -398,7 +428,11 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 	}
 
 	t.Run("without buffering", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("within limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(false, false, 1, 10, "hello", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -406,6 +440,8 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("request too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(false, false, 1, 10, "request limits are not enforced when not buffering", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -413,6 +449,8 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("response too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(false, false, 1, 10, "hello", "response limits are not enforced when not buffering")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -421,7 +459,11 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 	})
 
 	t.Run("with buffering but no additional disk limit", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("within limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 10, 10, "hello", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -429,12 +471,16 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("request too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 10, 10, "this one is too large", "ok")
 
 			require.Equal(t, http.StatusRequestEntityTooLarge, w.Result().StatusCode)
 		})
 
 		t.Run("response too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 10, 10, "hello", "this response is too large")
 
 			require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
@@ -442,7 +488,11 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 	})
 
 	t.Run("with buffering and a separate disk limit", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("within limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 5, 20, "hello", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -450,6 +500,8 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("request too large for memory but within the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 5, 20, "hello hello", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -457,11 +509,15 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("request too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 5, 20, "hello hello hello hello hello", "ok")
 
 			require.Equal(t, http.StatusRequestEntityTooLarge, w.Result().StatusCode)
 		})
 		t.Run("response too large for memory but within the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 5, 20, "hello", "hello hello")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -469,6 +525,8 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("response too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, true, 5, 20, "hello", "this is even longer than the disk limit")
 
 			require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
@@ -476,7 +534,11 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 	})
 
 	t.Run("when buffering requests but not responses", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("within limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, false, 10, 10, "hello", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -484,12 +546,16 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("request too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, false, 10, 10, "this one is too large", "ok")
 
 			require.Equal(t, http.StatusRequestEntityTooLarge, w.Result().StatusCode)
 		})
 
 		t.Run("response too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(true, false, 10, 10, "hello", "this response is very large")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -498,7 +564,11 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 	})
 
 	t.Run("when buffering responses but not requests", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("within limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(false, true, 10, 10, "hello", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -506,6 +576,8 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("request too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(false, true, 10, 10, "this one is too large", "ok")
 
 			require.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -513,6 +585,8 @@ func TestTarget_EnforceMaxBodySizes(t *testing.T) {
 		})
 
 		t.Run("response too large for the limit", func(t *testing.T) {
+			t.Parallel()
+
 			w := sendRequest(false, true, 10, 10, "hello", "this response is very large")
 
 			require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)


### PR DESCRIPTION
# Motivation
The motivation of this PR is to speed up the tests using Go's `t.Parallel()` in each test where parallelism is allowed, which is all of them locally.

Calling `t.Parallel()` in each test allows the tests to be called concurrently, which leads to a faster feedback loop from tests. While this might not have a huge impact now, it could help with testing times as more tests are written.

This is a cool feature of Go and I thought it might be a helpful addition to this project, but if you've already considered this and don't want it for whatever reason - no big deal.

## Further information
[Definition of t.Parallel() in Go documentation](https://pkg.go.dev/testing#T.Parallel)