### PR TITLE
Detect event-stream content type properly

### DIFF
--- a/internal/server/response_buffer_middleware.go
+++ b/internal/server/response_buffer_middleware.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 )
 
 type ResponseBufferMiddleware struct {
@@ -82,7 +83,8 @@ func (w *bufferedResponseWriter) WriteHeader(statusCode int) {
 }
 
 func (w *bufferedResponseWriter) ShouldSwitchToUnbuffered() bool {
-	return w.Header().Get("Content-Type") == "text/event-stream"
+	contentType, _, _ := strings.Cut(w.Header().Get("Content-Type"), ";")
+	return contentType == "text/event-stream"
 }
 
 func (w *bufferedResponseWriter) SwitchToUnbuffered() {


### PR DESCRIPTION
If the content type of an event stream includes a charset, we were failing to detect it, and thus failing to disable buffering automatically for that response. We should be ignoring the charset portion when matching.

Fixes #54.