### PR TITLE
Example maintenance mode

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -17,3 +17,14 @@ And then access the proxy from a browser at http://localhost/.
 Or, to list the currently deployed services:
 
     docker compose exec proxy kamal-proxy ls
+
+## Maintenance mode
+
+Create a container that handles your application maintenance mode. In this
+container, it should handle the `/up` healthcheck. It should also handle every
+other routes and display your maintenance page.
+
+To turn on maintenance mode for any of your service, simple run the Deploy
+command to set the target to the maintenance app container:
+
+    docker compose exec proxy kamal-proxy deploy service1 --target example-maintenance-1

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -11,3 +11,6 @@ services:
     deploy:
       replicas: 4
     restart: unless-stopped
+  maintenance:
+    build: ./maintenance
+    restart: unless-stopped

--- a/example/maintenance/Dockerfile
+++ b/example/maintenance/Dockerfile
@@ -1,0 +1,11 @@
+from golang:1.23.2 as build
+workdir /app
+copy . .
+env CGO_ENABLED=0
+run go build -o maintenance main.go
+
+from scratch as base
+copy --from=build /app/maintenance /usr/local/bin/
+expose 80
+
+cmd [ "maintenance" ]

--- a/example/maintenance/main.go
+++ b/example/maintenance/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+)
+
+func upHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func maintenaceHandler(host string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("Request", "host", host, "request_id", r.Header.Get("X-Request-ID"), "method", r.Method, "url", r.URL)
+
+		w.Header().Add("Content-Type", "text/html")
+		fmt.Fprintf(w, "<body><strong>%s</strong> undergoing maintenance.</body>\n",
+			host,
+		)
+	}
+}
+
+func main() {
+	host, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+
+	http.HandleFunc("/up", upHandler)
+	http.HandleFunc("/", maintenaceHandler(host))
+
+	panic(http.ListenAndServe(":80", nil))
+}


### PR DESCRIPTION
User's of kamal-proxy only needs to redeploy their web service to a new target. The target must be a container that handle health check url and returns maintenance page on every other route.