### PR TITLE
Log a status of 499 if the client cancels the request

### DIFF
--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -312,7 +312,7 @@ func (t *Target) handleProxyError(w http.ResponseWriter, r *http.Request, err er
 
 	if t.isDraining(err) {
 		slog.Info("Request cancelled due to draining", "target", t.Target(), "path", r.URL.Path)
-		SetErrorResponse(w, r, http.StatusBadGateway, nil)
+		SetErrorResponse(w, r, http.StatusGatewayTimeout, nil)
 		return
 	}
 

--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -146,6 +146,21 @@ func TestTarget_ServeWebSocket(t *testing.T) {
 	})
 }
 
+func TestTarget_CancelledRequestsHaveStatus499(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
+		cancel()
+	})
+
+	testServeRequestWithTarget(t, target, w, req)
+
+	require.Equal(t, 499, w.Result().StatusCode)
+	require.Empty(t, string(w.Body.String()))
+}
+
 func TestTarget_PreserveTargetHeader(t *testing.T) {
 	var requestTarget string
 
@@ -339,7 +354,10 @@ func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {
 	for i := 0; i < n; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
-		go testServeRequestWithTarget(t, target, w, req)
+		go func() {
+			testServeRequestWithTarget(t, target, w, req)
+			assert.Equal(t, http.StatusBadGateway, w.Result().StatusCode)
+		}()
 	}
 
 	started.Wait()

--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -356,7 +356,7 @@ func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {
 		w := httptest.NewRecorder()
 		go func() {
 			testServeRequestWithTarget(t, target, w, req)
-			assert.Equal(t, http.StatusBadGateway, w.Result().StatusCode)
+			assert.Equal(t, http.StatusGatewayTimeout, w.Result().StatusCode)
 		}()
 	}
 


### PR DESCRIPTION
Previously a client-cancelled request was logged as a proxy error, which is misleading. We can instead log it as 499, which is unambiguous and matches a convention used elsewhere.

Another situation in which requests may be cancelled is where we're forced to terminate incomplete requests during draining, because the drain timeout has expired before they've completed. In that case, we'll respond with a 504 Gateway Timeout, and log some additional context for clarity.

Closes #59