### PR TITLE
Adds middleware to insert X-Request-Start unix millis timestamp

### DIFF
--- a/internal/server/request_start_middleware.go
+++ b/internal/server/request_start_middleware.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	requestStartHeader = "X-Request-Start"
+)
+
+type RequestStartMiddleware struct {
+	next http.Handler
+}
+
+func WithRequestStartMiddleware(next http.Handler) http.Handler {
+	return &RequestStartMiddleware{
+		next: next,
+	}
+}
+
+func (h *RequestStartMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get(requestStartHeader) == "" {
+		r.Header.Set(requestStartHeader, strconv.FormatInt(time.Now().UnixMilli(), 10))
+	}
+	h.next.ServeHTTP(w, r)
+}

--- a/internal/server/request_start_middleware_test.go
+++ b/internal/server/request_start_middleware_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestStartMiddleware_AddsUnixMilliWhenNotPresent(t *testing.T) {
+	handler := WithRequestStartMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timestamp := r.Header.Get(requestStartHeader)
+		assert.NotEmpty(t, timestamp)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequestStartMiddleware_PreservesExistingHeaderWhenPresent(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timestamp := r.Header.Get(requestStartHeader)
+		assert.Equal(t, "1234", timestamp)
+	})
+	handler := WithRequestStartMiddleware(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set(requestStartHeader, "1234")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,10 +119,12 @@ func (s *Server) startCommandHandler() error {
 func (s *Server) buildHandler() http.Handler {
 	var handler http.Handler
 
+	// Note: handlers are executed in the inverse order.
 	handler = s.router
 	handler, _ = WithErrorPageMiddleware(pages.DefaultErrorPages, true, handler)
 	handler = WithLoggingMiddleware(slog.Default(), s.config.HttpPort, s.config.HttpsPort, handler)
 	handler = WithRequestIDMiddleware(handler)
+	handler = WithRequestStartMiddleware(handler)
 
 	return handler
 }


### PR DESCRIPTION
Implements #69

Note: I never wrote a line of Go before. I based everything on the `X-Request-ID` middleware implementation.

PS: `make test` passes for me locally