### PR TITLE
read http response body before closing it

### DIFF
--- a/internal/server/health_check.go
+++ b/internal/server/health_check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -94,7 +95,11 @@ func (hc *HealthCheck) check() {
 		hc.reportResult(false, err)
 		return
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		hc.reportResult(false, fmt.Errorf("%w (%d)", ErrorHealthCheckUnexpectedStatus, resp.StatusCode))

--- a/internal/server/health_check.go
+++ b/internal/server/health_check.go
@@ -95,11 +95,9 @@ func (hc *HealthCheck) check() {
 		hc.reportResult(false, err)
 		return
 	}
+	defer resp.Body.Close()
 
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-	}()
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		hc.reportResult(false, fmt.Errorf("%w (%d)", ErrorHealthCheckUnexpectedStatus, resp.StatusCode))


### PR DESCRIPTION
Per golang documentation, it isn't enough just to close the response body.
It's the best to read it before closing. Otherwise, there could be the resource leakage.

More information at <https://pkg.go.dev/net/http#Client.Do>
