### PR TITLE
Documenting --health-check-path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,18 @@ Because traffic is only routed to a new instance once it's healthy, and traffic
 is drained completely from old instances before they are removed, deployments
 take place with zero downtime.
 
-### Health check path
+### Customizing the health check
 
-For the apps that require a specific health check path, you can change it with the `--health-check-path` flag:
-    
+By default, Kamal Proxy will test the health of each service by sending a `GET`
+request to `/up`, once per second. A `200` response is considered healthy.
+
+If you need to customize the health checks for your application, there are a
+few `deploy` flags you can use. See the help for `--health-check-path`,
+`--health-check-timeout`, and `--health-check-interval`.
+
+For example, to change the health check path to something other than `/up`, you
+could:
+
     kamal-proxy deploy service1 --target web-1:3000 --health-check-path web/index.html
 
 ### Host-based routing

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Because traffic is only routed to a new instance once it's healthy, and traffic
 is drained completely from old instances before they are removed, deployments
 take place with zero downtime.
 
+### Health check path
+
+For the applications that require a specific health check path, you can change it with the `--health-check-path` flag:
+    
+    kamal-proxy deploy service1 --target web-1:3000 --health-check-path web/index.html
 
 ### Host-based routing
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ take place with zero downtime.
 
 ### Health check path
 
-For the applications that require a specific health check path, you can change it with the `--health-check-path` flag:
+For the apps that require a specific health check path, you can change it with the `--health-check-path` flag:
     
     kamal-proxy deploy service1 --target web-1:3000 --health-check-path web/index.html
 


### PR DESCRIPTION
Necessary to document the --health-check-path parameter.

Useful for apps like Plex that return a 401 status response code on the root URL but would return 200 with the correct health check path.