### PR TITLE
Enable graceful shutdown for https server

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -59,8 +60,8 @@ func (s *Server) Stop() {
 
 	PerformConcurrently(
 		func() { _ = s.commandHandler.Close() },
-		func() { _ = s.httpServer.Shutdown(ctx) },
-		func() { _ = s.httpsServer.Shutdown(ctx) },
+		func() { s.stopHTTPServer(ctx, s.httpServer) },
+		func() { s.stopHTTPServer(ctx, s.httpsServer) },
 	)
 
 	slog.Info("Server stopped")
@@ -130,4 +131,15 @@ func (s *Server) buildHandler() http.Handler {
 	handler = WithRequestStartMiddleware(handler)
 
 	return handler
+}
+
+func (s *Server) stopHTTPServer(ctx context.Context, server *http.Server) {
+	err := server.Shutdown(ctx)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			slog.Warn("Closing active connections")
+		} else {
+			slog.Error("Error while attempting to stop server", "error", err)
+		}
+	}
 }

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"sync"
+)
+
+func PerformConcurrently(fns ...func()) {
+	var wg sync.WaitGroup
+
+	wg.Add(len(fns))
+
+	for _, fn := range fns {
+		go func() {
+			defer wg.Done()
+			fn()
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
For some reason, the httpsServer does not shut down when server.Stop is called.
