### PR TITLE
Add `--tls-disable-redirect`

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -33,6 +33,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "Configure custom TLS certificate path (PEM format)")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "Configure custom TLS private key path (PEM format)")
+	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSDisableRedirect, "tls-disable-redirect", false, "Don't redirect HTTP traffic to HTTPS")
 
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DeployTimeout, "deploy-timeout", server.DefaultDeployTimeout, "Maximum time to wait for the new target to become healthy")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DrainTimeout, "drain-timeout", server.DefaultDrainTimeout, "Maximum time to allow existing connections to drain before removing old target")

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -43,6 +43,24 @@ func TestService_RedirectToHTTPSWhenTLSRequired(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)
 }
 
+func TestService_DontRedirectToHTTPSWhenTLSAndPlainHTTPAllowed(t *testing.T) {
+	service := testCreateService(t, []string{"example.com"}, ServiceOptions{TLSEnabled: true, TLSDisableRedirect: true}, defaultTargetOptions)
+
+	require.True(t, service.options.TLSEnabled)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	req = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	w = httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+}
+
 func TestService_UseStaticTLSCertificateWhenConfigured(t *testing.T) {
 	certPath, keyPath := prepareTestCertificateFiles(t)
 


### PR DESCRIPTION
Adds an option to disable the automatic HTTP -> HTTPS redirect when TLS is enabled for a service.

This option is off by default (i.e. the redirect is in place), but can be set on if you need to run a service as both HTTP and HTTPS.

Fixes #89