### PR TITLE
Path-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,39 @@ Only one service at a time can route a specific host:
     kamal-proxy deploy service2 --target web-2:3000 --host app1.example.com # succeeds
 
 
+### Path-based routing
+
+For applications that split their traffic to different services based on the
+request path, you can use path-based routing to mount services under different
+path prefixes.
+
+For example, to send all the requests for paths begining with `/api` to web-1,
+and the rest to web-2:
+
+    kamal-proxy deploy service1 --target web-1:3000 --path-prefix=/api
+    kamal-proxy deploy service2 --target web-2:3000
+
+By default, the path prefix will be stripped from the request before it is
+forwarded upstream. So in the example above, a request to `/api/users/123` will
+be forwarded to `web-1` as `/users/123`. To instead forward the request with
+the original path (including the prefix), specify `--strip-path-prefix=false`:
+
+    kamal-proxy deploy service1 --target web-1:3000 --path-prefix=/api --strip-path-prefix=false
+
+
 ### Automatic TLS
 
 Kamal Proxy can automatically obtain and renew TLS certificates for your
 applications. To enable this, add the `--tls` flag when deploying an instance:
 
     kamal-proxy deploy service1 --target web-1:3000 --host app1.example.com --tls
+
+Automatic TLS requires that hosts are specified (to ensure that certificates
+are not maliciously requests for arbitrary hostnames).
+
+Additionally, when using path-based routing, TLS options must be set on the
+root path. Services deployed to other paths on the same host will use the same
+TLS settings as those specified for the root path.
 
 
 ### Custom TLS certificate

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -43,7 +43,7 @@ func (c *listCommand) run(cmd *cobra.Command, args []string) error {
 
 func (c *listCommand) displayResponse(response server.ListResponse) {
 	table := NewTable()
-	table.AddRow([]string{"Service", "Host", "Target", "State", "TLS"})
+	table.AddRow([]string{"Service", "Host", "Path", "Target", "State", "TLS"})
 
 	sortedKeys := slices.Sorted(maps.Keys(response.Targets))
 	for _, name := range sortedKeys {
@@ -53,7 +53,7 @@ func (c *listCommand) displayResponse(response server.ListResponse) {
 			tls = "yes"
 		}
 
-		table.AddRow([]string{name, service.Host, service.Target, service.State, tls})
+		table.AddRow([]string{name, service.Host, service.Path, service.Target, service.State, tls})
 	}
 
 	table.Print()

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -20,6 +20,7 @@ type DeployArgs struct {
 	Service        string
 	TargetURL      string
 	Hosts          []string
+	PathPrefix     string
 	DeployTimeout  time.Duration
 	DrainTimeout   time.Duration
 	ServiceOptions ServiceOptions
@@ -114,7 +115,7 @@ func (h *CommandHandler) Close() error {
 }
 
 func (h *CommandHandler) Deploy(args DeployArgs, reply *bool) error {
-	return h.router.SetServiceTarget(args.Service, args.Hosts, args.TargetURL, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
+	return h.router.SetServiceTarget(args.Service, args.Hosts, args.PathPrefix, args.TargetURL, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
 }
 
 func (h *CommandHandler) Pause(args PauseArgs, reply *bool) error {

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -24,7 +24,7 @@ func TestRouter_ActiveServiceForHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
@@ -36,7 +36,7 @@ func TestRouter_Removing(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -51,7 +51,7 @@ func TestRouter_ActiveServiceForMultipleHosts(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"1.example.com", "2.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"1.example.com", "2.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -69,9 +69,9 @@ func TestRouter_UpdatingHostsOfActiveService(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"1.example.com", "2.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"1.example.com", "2.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"3.example.com", "2.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"3.example.com", "2.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendGETRequest(router, "http://1.example.com/")
 	assert.Equal(t, http.StatusNotFound, statusCode)
@@ -89,7 +89,7 @@ func TestRouter_ActiveServiceForUnknownHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendGETRequest(router, "http://other.example.com/")
 
@@ -100,7 +100,7 @@ func TestRouter_ActiveServiceForHostContainingPort(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com:80/")
 
@@ -112,7 +112,7 @@ func TestRouter_ActiveServiceWithoutHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
@@ -125,14 +125,14 @@ func TestRouter_ReplacingActiveService(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://dummy.example.com/")
 
@@ -149,23 +149,23 @@ func TestRouter_UpdatingOptions(t *testing.T) {
 
 	targetOptions.BufferRequests = true
 	targetOptions.MaxRequestBodySize = 10
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))
+	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusRequestEntityTooLarge, statusCode)
 
 	targetOptions.BufferRequests = false
 	targetOptions.MaxRequestBodySize = 0
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	statusCode, body := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))
+	statusCode, body := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
 	serviceOptions.TLSEnabled = true
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	statusCode, body = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))
+	statusCode, body = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusMovedPermanently, statusCode)
 	assert.Empty(t, body)
 }
@@ -175,24 +175,24 @@ func TestRouter_DeploymmentsWithErrorsDoNotUpdateService(t *testing.T) {
 	_, target := testBackend(t, "first", http.StatusOK)
 
 	ensureServiceIsHealthy := func() {
-		statusCode, body := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("Hello")))
+		statusCode, body := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://example.com/", strings.NewReader("Hello")))
 		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Equal(t, "first", body)
 	}
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	ensureServiceIsHealthy()
 
 	t.Run("custom TLS that is not valid", func(t *testing.T) {
 		serviceOptions := ServiceOptions{TLSEnabled: true, TLSCertificatePath: "not valid", TLSPrivateKeyPath: "not valid"}
-		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, "", target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 		ensureServiceIsHealthy()
 	})
 
 	t.Run("custom error pages that are not valid", func(t *testing.T) {
 		serviceOptions := ServiceOptions{ErrorPagePath: "not valid"}
-		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, "", target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 		ensureServiceIsHealthy()
 	})
@@ -202,20 +202,20 @@ func TestRouter_UpdatingPauseStateIndependentlyOfDeployments(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	router.PauseService("service1", time.Second, time.Millisecond*10)
 
-	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))
+	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusGatewayTimeout, statusCode)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	statusCode, _ = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))
+	statusCode, _ = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusGatewayTimeout, statusCode)
 
 	router.ResumeService("service1")
 
-	statusCode, _ = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com", strings.NewReader("Something longer than 10")))
+	statusCode, _ = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusOK, statusCode)
 }
 
@@ -224,14 +224,14 @@ func TestRouter_ChangingHostForService(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy2.example.com"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy2.example.com"}, "", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://dummy2.example.com/")
 
@@ -247,8 +247,8 @@ func TestRouter_ReusingHost(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	err := router.SetServiceTarget("service12", []string{"dummy.example.com"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	err := router.SetServiceTarget("service12", []string{"dummy.example.com"}, "", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 
 	require.Equal(t, ErrorHostInUse, err)
 
@@ -263,8 +263,8 @@ func TestRouter_ReusingEmptyHost(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	err := router.SetServiceTarget("service12", defaultEmptyHosts, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	err := router.SetServiceTarget("service12", defaultEmptyHosts, "", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 
 	require.Equal(t, ErrorHostInUse, err)
 
@@ -278,8 +278,8 @@ func TestRouter_RoutingMultipleHosts(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"s1.example.com"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("service2", []string{"s2.example.com"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"s1.example.com"}, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service2", []string{"s2.example.com"}, "", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://s1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -290,13 +290,94 @@ func TestRouter_RoutingMultipleHosts(t *testing.T) {
 	assert.Equal(t, "second", body)
 }
 
+func TestRouter_PathBasedRoutingStripPrefix(t *testing.T) {
+	router := testRouter(t)
+	_, backend := testBackendWithHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.URL.String()))
+	})
+
+	firstOptions := defaultTargetOptions
+	firstOptions.StripPrefix = "/app"
+	secondOptions := defaultTargetOptions
+	secondOptions.StripPrefix = "/api/internal"
+
+	require.NoError(t, router.SetServiceTarget("service1", []string{"example.com"}, "", backend, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service2", []string{"example.com"}, "/app", backend, defaultServiceOptions, firstOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service3", []string{"example.com"}, "/api/internal", backend, defaultServiceOptions, secondOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+
+	statusCode, body := sendGETRequest(router, "http://example.com/app/show")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "/show", body)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/api/internal/something?a=b")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "/something?a=b", body)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/api/external/something")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "/api/external/something", body)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/appointment")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "/appointment", body)
+}
+
+func TestRouter_PathBasedRoutingWithHosts(t *testing.T) {
+	router := testRouter(t)
+	_, first := testBackend(t, "first", http.StatusOK)
+	_, second := testBackend(t, "second", http.StatusOK)
+
+	require.NoError(t, router.SetServiceTarget("service1", []string{"example.com"}, "/first", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service2", []string{"example.com"}, "/second", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+
+	statusCode, body := sendGETRequest(router, "http://example.com/first")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "first", body)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/second")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "second", body)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/third")
+	assert.Equal(t, http.StatusNotFound, statusCode)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/")
+	assert.Equal(t, http.StatusNotFound, statusCode)
+}
+
+func TestRouter_PathBasedRoutingWithDefaultHost(t *testing.T) {
+	router := testRouter(t)
+	_, first := testBackend(t, "first", http.StatusOK)
+	_, second := testBackend(t, "second", http.StatusOK)
+	_, third := testBackend(t, "third", http.StatusOK)
+
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, "/first", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service2", defaultEmptyHosts, "/second", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service3", []string{"third.example.com"}, "/second", third, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+
+	statusCode, body := sendGETRequest(router, "http://example.com/first")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "first", body)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/second")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "second", body)
+
+	statusCode, body = sendGETRequest(router, "http://third.example.com/second/path")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "third", body)
+
+	statusCode, body = sendGETRequest(router, "http://example.com/")
+	assert.Equal(t, http.StatusNotFound, statusCode)
+}
+
 func TestRouter_TargetWithoutHostActsAsWildcard(t *testing.T) {
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"s1.example.com"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", []string{"s1.example.com"}, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, "", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://s1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -317,9 +398,9 @@ func TestRouter_TargetsAllowWildcardSubdomains(t *testing.T) {
 	_, second := testBackend(t, "second", http.StatusOK)
 	_, fallback := testBackend(t, "fallback", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("first", []string{"*.first.example.com"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("second", []string{"*.second.example.com"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("fallback", defaultEmptyHosts, fallback, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("first", []string{"*.first.example.com"}, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("second", []string{"*.second.example.com"}, "", second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("fallback", defaultEmptyHosts, "", fallback, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://app.first.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -338,7 +419,7 @@ func TestRouter_WildcardDomainsCannotBeUsedWithAutomaticTLS(t *testing.T) {
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 
-	err := router.SetServiceTarget("first", []string{"first.example.com", "*.first.example.com"}, first, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	err := router.SetServiceTarget("first", []string{"first.example.com", "*.first.example.com"}, "", first, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 	require.Equal(t, ErrorAutomaticTLSDoesNotSupportWildcards, err)
 }
 
@@ -346,7 +427,7 @@ func TestRouter_ServiceFailingToBecomeHealthy(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "", http.StatusInternalServerError)
 
-	err := router.SetServiceTarget("example", []string{"example.com"}, target, defaultServiceOptions, defaultTargetOptions, time.Millisecond*20, DefaultDrainTimeout)
+	err := router.SetServiceTarget("example", []string{"example.com"}, "", target, defaultServiceOptions, defaultTargetOptions, time.Millisecond*20, DefaultDrainTimeout)
 	assert.ErrorIs(t, err, ErrorTargetFailedToBecomeHealthy)
 
 	statusCode, _ := sendGETRequest(router, "http://example.com/")
@@ -359,7 +440,7 @@ func TestRouter_EnablingRollout(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	require.NoError(t, router.SetRolloutTarget("service1", second, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	checkResponse := func(expected string) {
@@ -387,27 +468,37 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
+	_, third := testBackend(t, "third", http.StatusOK)
 
 	router := NewRouter(statePath)
-	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("other", []string{"other.example.com"}, second, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, "", first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("other1", []string{"other.example.com"}, "", second, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetServiceTarget("other2", []string{"other.example.com"}, "/api", third, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	statusCode, body := sendGETRequest(router, "http://something.example.com")
+	statusCode, body := sendGETRequest(router, "http://something.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
 	statusCode, _ = sendGETRequest(router, "http://other.example.com/")
 	assert.Equal(t, http.StatusMovedPermanently, statusCode)
+
+	statusCode, body = sendGETRequest(router, "https://other.example.com/api")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "third", body)
 
 	router = NewRouter(statePath)
 	router.RestoreLastSavedState()
 
-	statusCode, body = sendGETRequest(router, "http://something.example.com")
+	statusCode, body = sendGETRequest(router, "http://something.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
 	statusCode, _ = sendGETRequest(router, "http://other.example.com/")
 	assert.Equal(t, http.StatusMovedPermanently, statusCode)
+
+	statusCode, body = sendGETRequest(router, "https://other.example.com/api")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "third", body)
 }
 
 // Helpers

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -410,56 +410,6 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 	assert.Equal(t, http.StatusMovedPermanently, statusCode)
 }
 
-func TestHostServiceMap_ServiceForHost(t *testing.T) {
-	hsm := HostServiceMap{
-		"example.com":     &Service{name: "1"},
-		"app.example.com": &Service{name: "2"},
-		"api.example.com": &Service{name: "3"},
-		"*.example.com":   &Service{name: "4"},
-		"":                &Service{name: "5"},
-	}
-
-	assert.Equal(t, "1", hsm.ServiceForHost("example.com").name)
-	assert.Equal(t, "2", hsm.ServiceForHost("app.example.com").name)
-	assert.Equal(t, "3", hsm.ServiceForHost("api.example.com").name)
-	assert.Equal(t, "4", hsm.ServiceForHost("anything.example.com").name)
-
-	assert.Equal(t, "5", hsm.ServiceForHost("extra.level.example.com").name)
-	assert.Equal(t, "5", hsm.ServiceForHost("other.com").name)
-
-	hsm = HostServiceMap{
-		"example.com": &Service{name: "1"},
-	}
-
-	assert.Nil(t, hsm.ServiceForHost("app.example.com"))
-}
-
-func BenchmarkHostServiceMap_WilcardRouting(b *testing.B) {
-	hsm := HostServiceMap{
-		"one.example.com":   &Service{},
-		"*.two.example.com": &Service{},
-		"":                  &Service{},
-	}
-
-	b.Run("exact match", func(b *testing.B) {
-		for b.Loop() {
-			_ = hsm.ServiceForHost("one.example.com")
-		}
-	})
-
-	b.Run("wildcard match", func(b *testing.B) {
-		for b.Loop() {
-			_ = hsm.ServiceForHost("anything.two.example.com")
-		}
-	})
-
-	b.Run("default match", func(b *testing.B) {
-		for b.Loop() {
-			_ = hsm.ServiceForHost("missing.example.com")
-		}
-	})
-}
-
 // Helpers
 
 func testRouter(t *testing.T) *Router {

--- a/internal/server/service_map.go
+++ b/internal/server/service_map.go
@@ -4,18 +4,30 @@ import (
 	"iter"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 )
 
+const (
+	rootPath = "/"
+)
+
+type pathBinding struct {
+	pathPrefix string
+	service    *Service
+}
+
+type requestServiceMap map[string][]*pathBinding
+
 type ServiceMap struct {
-	services       map[string]*Service
-	hostServiceMap map[string]*Service
+	services          map[string]*Service
+	requestServiceMap requestServiceMap
 }
 
 func NewServiceMap() *ServiceMap {
 	return &ServiceMap{
-		services:       map[string]*Service{},
-		hostServiceMap: map[string]*Service{},
+		services:          map[string]*Service{},
+		requestServiceMap: requestServiceMap{},
 	}
 }
 
@@ -25,12 +37,12 @@ func (m *ServiceMap) Get(name string) *Service {
 
 func (m *ServiceMap) Set(service *Service) {
 	m.services[service.name] = service
-	m.updateHostMappings()
+	m.updateRequestServiceMap()
 }
 
 func (m *ServiceMap) Remove(name string) {
 	delete(m.services, name)
-	m.updateHostMappings()
+	m.updateRequestServiceMap()
 }
 
 func (m *ServiceMap) All() iter.Seq2[string, *Service] {
@@ -43,35 +55,22 @@ func (m *ServiceMap) All() iter.Seq2[string, *Service] {
 	}
 }
 
-func (m *ServiceMap) CheckHostAvailability(name string, hosts []string) *Service {
-	if len(hosts) == 0 {
-		hosts = []string{""}
-	}
+func (m *ServiceMap) CheckAvailability(name string, hosts []string, pathPrefix string) *Service {
+	pathPrefix = NormalizePath(pathPrefix)
 
-	for _, host := range hosts {
-		service := m.hostServiceMap[host]
-		if service != nil && service.name != name {
-			return service
+	for _, host := range NormalizeHosts(hosts) {
+		bindings := m.requestServiceMap[host]
+		for _, binding := range bindings {
+			if pathPrefix == binding.pathPrefix && binding.service.name != name {
+				return binding.service
+			}
 		}
 	}
 	return nil
 }
 
 func (m *ServiceMap) ServiceForHost(host string) *Service {
-	service, ok := m.hostServiceMap[host]
-	if ok {
-		return service
-	}
-
-	sep := strings.Index(host, ".")
-	if sep > 0 {
-		service, ok := m.hostServiceMap["*"+host[sep:]]
-		if ok {
-			return service
-		}
-	}
-
-	return m.hostServiceMap[""]
+	return m.serviceFor(host, rootPath)
 }
 
 func (m *ServiceMap) ServiceForRequest(req *http.Request) *Service {
@@ -84,23 +83,100 @@ func (m *ServiceMap) ServiceForRequest(req *http.Request) *Service {
 		}
 	}
 
-	return m.ServiceForHost(host)
+	return m.serviceFor(host, req.URL.Path)
 }
 
 // Private
 
-func (m *ServiceMap) updateHostMappings() {
-	hostServices := map[string]*Service{}
+func (m *ServiceMap) serviceFor(host, path string) *Service {
+	bindings := m.bindingsForHost(host)
+	if bindings == nil {
+		return nil
+	}
 
-	for _, service := range m.services {
-		if len(service.hosts) == 0 {
-			hostServices[""] = service
-			continue
-		}
-		for _, host := range service.hosts {
-			hostServices[host] = service
+	for _, binding := range bindings {
+		if strings.HasPrefix(EnsureTrailingSlash(path), EnsureTrailingSlash(binding.pathPrefix)) {
+			return binding.service
 		}
 	}
 
-	m.hostServiceMap = hostServices
+	return nil
+}
+
+func (m *ServiceMap) bindingsForHost(host string) []*pathBinding {
+	bindings, ok := m.requestServiceMap[host]
+	if ok {
+		return bindings
+	}
+
+	sep := strings.Index(host, ".")
+	if sep > 0 {
+		bindings, ok = m.requestServiceMap["*"+host[sep:]]
+		if ok {
+			return bindings
+		}
+	}
+
+	return m.requestServiceMap[""]
+}
+
+func (m *ServiceMap) updateRequestServiceMap() {
+	requestServiceMap := requestServiceMap{}
+
+	for _, service := range m.services {
+		pathPrefix := NormalizePath(service.pathPrefix)
+		for _, host := range NormalizeHosts(service.hosts) {
+			bindings := requestServiceMap[host]
+			if bindings == nil {
+				bindings = []*pathBinding{}
+			}
+			bindings = append(bindings, &pathBinding{pathPrefix: pathPrefix, service: service})
+			requestServiceMap[host] = bindings
+		}
+
+		for _, bindings := range requestServiceMap {
+			slices.SortFunc(bindings, func(a, b *pathBinding) int { return len(b.pathPrefix) - len(a.pathPrefix) })
+		}
+	}
+
+	m.requestServiceMap = requestServiceMap
+	m.syncTLSOptionsFromRootDomain()
+}
+
+func (m *ServiceMap) syncTLSOptionsFromRootDomain() {
+	for _, service := range m.services {
+		if NormalizePath(service.pathPrefix) != rootPath {
+			host := ""
+			if len(service.hosts) > 0 {
+				host = service.hosts[0]
+			}
+
+			rootService := m.ServiceForHost(host)
+			if rootService != nil {
+				service.options.TLSEnabled = rootService.options.TLSEnabled
+				service.options.TLSDisableRedirect = rootService.options.TLSDisableRedirect
+			} else {
+				service.options.TLSEnabled = defaultServiceOptions.TLSEnabled
+				service.options.TLSDisableRedirect = defaultServiceOptions.TLSDisableRedirect
+			}
+		}
+	}
+}
+
+func NormalizeHosts(hosts []string) []string {
+	if len(hosts) == 0 {
+		return []string{""}
+	}
+	return hosts
+}
+
+func NormalizePath(path string) string {
+	return "/" + strings.Trim(path, "/")
+}
+
+func EnsureTrailingSlash(path string) string {
+	if !strings.HasSuffix(path, "/") {
+		return path + "/"
+	}
+	return path
 }

--- a/internal/server/service_map.go
+++ b/internal/server/service_map.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"iter"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type ServiceMap struct {
+	services       map[string]*Service
+	hostServiceMap map[string]*Service
+}
+
+func NewServiceMap() *ServiceMap {
+	return &ServiceMap{
+		services:       map[string]*Service{},
+		hostServiceMap: map[string]*Service{},
+	}
+}
+
+func (m *ServiceMap) Get(name string) *Service {
+	return m.services[name]
+}
+
+func (m *ServiceMap) Set(service *Service) {
+	m.services[service.name] = service
+	m.updateHostMappings()
+}
+
+func (m *ServiceMap) Remove(name string) {
+	delete(m.services, name)
+	m.updateHostMappings()
+}
+
+func (m *ServiceMap) All() iter.Seq2[string, *Service] {
+	return func(yield func(string, *Service) bool) {
+		for name, service := range m.services {
+			if !yield(name, service) {
+				return
+			}
+		}
+	}
+}
+
+func (m *ServiceMap) CheckHostAvailability(name string, hosts []string) *Service {
+	if len(hosts) == 0 {
+		hosts = []string{""}
+	}
+
+	for _, host := range hosts {
+		service := m.hostServiceMap[host]
+		if service != nil && service.name != name {
+			return service
+		}
+	}
+	return nil
+}
+
+func (m *ServiceMap) ServiceForHost(host string) *Service {
+	service, ok := m.hostServiceMap[host]
+	if ok {
+		return service
+	}
+
+	sep := strings.Index(host, ".")
+	if sep > 0 {
+		service, ok := m.hostServiceMap["*"+host[sep:]]
+		if ok {
+			return service
+		}
+	}
+
+	return m.hostServiceMap[""]
+}
+
+func (m *ServiceMap) ServiceForRequest(req *http.Request) *Service {
+	host, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		host = req.Host
+	}
+
+	return m.ServiceForHost(host)
+}
+
+// Private
+
+func (m *ServiceMap) updateHostMappings() {
+	hostServices := map[string]*Service{}
+
+	for _, service := range m.services {
+		if len(service.hosts) == 0 {
+			hostServices[""] = service
+			continue
+		}
+		for _, host := range service.hosts {
+			hostServices[host] = service
+		}
+	}
+
+	m.hostServiceMap = hostServices
+}

--- a/internal/server/service_map.go
+++ b/internal/server/service_map.go
@@ -75,9 +75,13 @@ func (m *ServiceMap) ServiceForHost(host string) *Service {
 }
 
 func (m *ServiceMap) ServiceForRequest(req *http.Request) *Service {
-	host, _, err := net.SplitHostPort(req.Host)
-	if err != nil {
-		host = req.Host
+	host := req.Host
+
+	if strings.Index(host, ":") > 0 {
+		splitHost, _, err := net.SplitHostPort(host)
+		if err == nil {
+			host = splitHost
+		}
 	}
 
 	return m.ServiceForHost(host)

--- a/internal/server/service_map_test.go
+++ b/internal/server/service_map_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceMap_ServiceForHost(t *testing.T) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{"example.com"}})
+	sm.Set(&Service{name: "2", hosts: []string{"app.example.com"}})
+	sm.Set(&Service{name: "3", hosts: []string{"api.example.com"}})
+	sm.Set(&Service{name: "4", hosts: []string{"*.example.com"}})
+	sm.Set(&Service{name: "5"})
+
+	assert.Equal(t, "1", sm.ServiceForHost("example.com").name)
+	assert.Equal(t, "2", sm.ServiceForHost("app.example.com").name)
+	assert.Equal(t, "3", sm.ServiceForHost("api.example.com").name)
+	assert.Equal(t, "4", sm.ServiceForHost("anything.example.com").name)
+
+	assert.Equal(t, "5", sm.ServiceForHost("extra.level.example.com").name)
+	assert.Equal(t, "5", sm.ServiceForHost("other.com").name)
+
+	sm = NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{"example.com"}})
+
+	assert.Nil(t, sm.ServiceForHost("app.example.com"))
+}
+
+func TestServiceMap_CheckHostAvailability(t *testing.T) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{"example.com"}})
+	sm.Set(&Service{name: "2", hosts: []string{"app.example.com"}})
+
+	assert.Nil(t, sm.CheckHostAvailability("2", []string{"app.example.com"}))
+	assert.Nil(t, sm.CheckHostAvailability("3", []string{"api.example.com"}))
+	assert.Nil(t, sm.CheckHostAvailability("4", []string{""}))
+
+	assert.Equal(t, "2", sm.CheckHostAvailability("3", []string{"app.example.com"}).name)
+
+	sm.Set(&Service{name: "3", hosts: []string{}})
+	assert.Equal(t, "3", sm.CheckHostAvailability("4", []string{""}).name)
+}
+
+func BenchmarkServiceMap_WilcardRouting(b *testing.B) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{"one.example.com"}})
+	sm.Set(&Service{name: "2", hosts: []string{"*.two.example.com"}})
+	sm.Set(&Service{name: "3"})
+
+	b.Run("exact match", func(b *testing.B) {
+		for b.Loop() {
+			_ = sm.ServiceForHost("one.example.com")
+		}
+	})
+
+	b.Run("wildcard match", func(b *testing.B) {
+		for b.Loop() {
+			_ = sm.ServiceForHost("anything.two.example.com")
+		}
+	})
+
+	b.Run("default match", func(b *testing.B) {
+		for b.Loop() {
+			_ = sm.ServiceForHost("missing.example.com")
+		}
+	})
+}

--- a/internal/server/service_map_test.go
+++ b/internal/server/service_map_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,19 +30,88 @@ func TestServiceMap_ServiceForHost(t *testing.T) {
 	assert.Nil(t, sm.ServiceForHost("app.example.com"))
 }
 
-func TestServiceMap_CheckHostAvailability(t *testing.T) {
+func TestServiceMap_ServiceForRequest(t *testing.T) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{"example.com"}})
+	sm.Set(&Service{name: "2", hosts: []string{"example.com"}, pathPrefix: "/api"})
+	sm.Set(&Service{name: "3", hosts: []string{"example.com"}, pathPrefix: "/api/special"})
+	sm.Set(&Service{name: "4", hosts: []string{"other.example.com"}, pathPrefix: "/api"})
+	sm.Set(&Service{name: "5", pathPrefix: "/api"})
+	sm.Set(&Service{name: "6"})
+
+	assert.Equal(t, "1", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://example.com/", nil)).name)
+	assert.Equal(t, "1", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://example.com/random", nil)).name)
+	assert.Equal(t, "1", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://example.com/apiary", nil)).name)
+	assert.Equal(t, "2", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://example.com/api", nil)).name)
+	assert.Equal(t, "3", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://example.com/api/special", nil)).name)
+	assert.Equal(t, "4", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://other.example.com/api/test", nil)).name)
+	assert.Equal(t, "5", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://second.example.com/api/test", nil)).name)
+	assert.Equal(t, "6", sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, "http://second.example.com/non-api/test", nil)).name)
+}
+
+func TestServiceMap_CheckAvailability(t *testing.T) {
 	sm := NewServiceMap()
 	sm.Set(&Service{name: "1", hosts: []string{"example.com"}})
 	sm.Set(&Service{name: "2", hosts: []string{"app.example.com"}})
+	sm.Set(&Service{name: "3", hosts: []string{"app.example.com"}, pathPrefix: "/api"})
 
-	assert.Nil(t, sm.CheckHostAvailability("2", []string{"app.example.com"}))
-	assert.Nil(t, sm.CheckHostAvailability("3", []string{"api.example.com"}))
-	assert.Nil(t, sm.CheckHostAvailability("4", []string{""}))
+	assert.Nil(t, sm.CheckAvailability("2", []string{"app.example.com"}, ""))
 
-	assert.Equal(t, "2", sm.CheckHostAvailability("3", []string{"app.example.com"}).name)
+	assert.Nil(t, sm.CheckAvailability("4", []string{"api.example.com"}, ""))
+	assert.Nil(t, sm.CheckAvailability("4", []string{""}, ""))
+	assert.Nil(t, sm.CheckAvailability("4", []string{"app.example.com"}, "/app"))
+	assert.Nil(t, sm.CheckAvailability("3", []string{"app.example.com"}, "/api"))
 
-	sm.Set(&Service{name: "3", hosts: []string{}})
-	assert.Equal(t, "3", sm.CheckHostAvailability("4", []string{""}).name)
+	assert.Equal(t, "2", sm.CheckAvailability("4", []string{"app.example.com"}, "").name)
+	assert.Equal(t, "3", sm.CheckAvailability("4", []string{"app.example.com"}, "/api").name)
+}
+
+func TestServiceMap_SyncingTLSSettingsFromRootPath(t *testing.T) {
+	optionsWithTLS := ServiceOptions{
+		TLSEnabled:         true,
+		TLSDisableRedirect: true,
+	}
+
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{"1.example.com"}, options: optionsWithTLS})
+	sm.Set(&Service{name: "2", hosts: []string{"1.example.com"}, pathPrefix: "/api"})
+	sm.Set(&Service{name: "3", hosts: []string{"2.example.com"}, options: defaultServiceOptions})
+	sm.Set(&Service{name: "4", hosts: []string{"2.example.com"}, pathPrefix: "/api"})
+
+	assert.True(t, sm.Get("1").options.TLSEnabled)
+	assert.True(t, sm.Get("1").options.TLSDisableRedirect)
+	assert.True(t, sm.Get("2").options.TLSEnabled)
+	assert.True(t, sm.Get("2").options.TLSDisableRedirect)
+
+	assert.False(t, sm.Get("3").options.TLSEnabled)
+	assert.False(t, sm.Get("3").options.TLSDisableRedirect)
+	assert.False(t, sm.Get("4").options.TLSEnabled)
+	assert.False(t, sm.Get("4").options.TLSDisableRedirect)
+
+	sm.Remove("1")
+
+	assert.False(t, sm.Get("2").options.TLSEnabled)
+	assert.False(t, sm.Get("2").options.TLSDisableRedirect)
+}
+
+func TestServiceMap_CheckHostAvailability_EmptyHostsFirst(t *testing.T) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{}})
+
+	assert.Nil(t, sm.CheckAvailability("2", []string{"app.example.com"}, ""))
+}
+
+func BenchmarkServiceMap_SingleServiceRouting(b *testing.B) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1"})
+
+	b.Run("exact match", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://one.example.com/", nil)
+
+		for b.Loop() {
+			_ = sm.ServiceForRequest(req)
+		}
+	})
 }
 
 func BenchmarkServiceMap_WilcardRouting(b *testing.B) {
@@ -50,20 +121,66 @@ func BenchmarkServiceMap_WilcardRouting(b *testing.B) {
 	sm.Set(&Service{name: "3"})
 
 	b.Run("exact match", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://one.example.com/", nil)
+
 		for b.Loop() {
-			_ = sm.ServiceForHost("one.example.com")
+			_ = sm.ServiceForRequest(req)
 		}
 	})
 
 	b.Run("wildcard match", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://anything.two.example.com/", nil)
+
 		for b.Loop() {
-			_ = sm.ServiceForHost("anything.two.example.com")
+			_ = sm.ServiceForRequest(req)
 		}
 	})
 
 	b.Run("default match", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://missing.example.com/", nil)
+
 		for b.Loop() {
-			_ = sm.ServiceForHost("missing.example.com")
+			_ = sm.ServiceForRequest(req)
+		}
+	})
+}
+
+func BenchmarkServiceMap_HostAndPathBasedRouting(b *testing.B) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", hosts: []string{"one.example.com"}, pathPrefix: "/api"})
+	sm.Set(&Service{name: "2", hosts: []string{"one.example.com"}})
+	sm.Set(&Service{name: "3", pathPrefix: "/app"})
+	sm.Set(&Service{name: "4"})
+
+	b.Run("host and path match", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://one.example.com/api", nil)
+
+		for b.Loop() {
+			_ = sm.ServiceForRequest(req)
+		}
+	})
+
+	b.Run("host and default path", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://one.example.com/", nil)
+
+		for b.Loop() {
+			_ = sm.ServiceForRequest(req)
+		}
+	})
+
+	b.Run("path match", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/app", nil)
+
+		for b.Loop() {
+			_ = sm.ServiceForRequest(req)
+		}
+	})
+
+	b.Run("default", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+
+		for b.Loop() {
+			_ = sm.ServiceForRequest(req)
 		}
 	})
 }

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -177,7 +177,7 @@ func testCreateServiceWithHandler(t *testing.T, hosts []string, options ServiceO
 	target, err := NewTarget(serverURL.Host, targetOptions)
 	require.NoError(t, err)
 
-	service, err := NewService("test", hosts, options)
+	service, err := NewService("test", hosts, "", options)
 	require.NoError(t, err)
 	service.active = target
 

--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 )
@@ -64,6 +65,7 @@ type TargetOptions struct {
 	LogRequestHeaders   []string          `json:"log_request_headers"`
 	LogResponseHeaders  []string          `json:"log_response_headers"`
 	ForwardHeaders      bool              `json:"forward_headers"`
+	StripPrefix         string            `json:"strip_prefix"`
 }
 
 func (to *TargetOptions) canonicalizeLogHeaders() {
@@ -273,6 +275,10 @@ func (t *Target) rewrite(req *httputil.ProxyRequest) {
 	// In our case, we don't make any decisions based on the query params, so it's
 	// safe for us to pass them through verbatim.
 	req.Out.URL.RawQuery = req.In.URL.RawQuery
+
+	if t.options.StripPrefix != "" {
+		req.Out.URL.Path = strings.TrimPrefix(req.Out.URL.Path, t.options.StripPrefix)
+	}
 }
 
 func (t *Target) forwardHeaders(req *httputil.ProxyRequest) {


### PR DESCRIPTION
Building on the idea presented in #93, this provides the ability to deploy a service under a specific path.

- Adds a new `--path-prefix` option for deployments. When specified, only requests beginning with that prefix will be routed to the service. This allows multiple services to share the same host(s), by routing traffic according to the path.

- `--path-prefix` needn't be a single path segment, but the prefix must split on a path boundary. For example, a prefix of `/api/internal` is valid, and will match a path of `/api/internal/users/123`, or `/api/internal`; but it would not match `/api/internal2`.

- By default, the prefix will be removed before forwarding the request to the target service. So, given a `--path-prefix=/api`, a request to `/api/users` will reach the target as `/users`.

- In the case where the prefix should be preserved, we can set `--strip-path-prefix=false`. In this case, the full path is preserved.

Closes #48 