### PR TITLE
Load balancing via multiple service targets

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -28,8 +28,8 @@ func newDeployCommand() *deployCommand {
 	}
 
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.TargetURLs, "target", []string{}, "Target host(s) to deploy")
-	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.Hosts, "host", []string{}, "Host(s) to serve this target on (empty for wildcard)")
-	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.PathPrefixes, "path-prefix", []string{}, "Deploy the service below the specified path(s)")
+	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.ServiceOptions.Hosts, "host", []string{}, "Host(s) to serve this target on (empty for wildcard)")
+	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.ServiceOptions.PathPrefixes, "path-prefix", []string{}, "Deploy the service below the specified path(s)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.StripPrefix, "strip-path-prefix", true, "With --path-prefix, strip prefix from request before forwarding")
 
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSEnabled, "tls", false, "Configure TLS for this target (requires a non-empty host)")
@@ -82,7 +82,7 @@ func (c *deployCommand) run(cmd *cobra.Command, args []string) error {
 }
 
 func (c *deployCommand) preRun(cmd *cobra.Command, args []string) error {
-	c.args.PathPrefixes = server.NormalizePathPrefixes(c.args.PathPrefixes)
+	c.args.ServiceOptions.Normalize()
 
 	if cmd.Flags().Changed("max-request-body") && !cmd.Flags().Changed("buffer-requests") {
 		return fmt.Errorf("max-request-body can only be set when request buffering is enabled")
@@ -97,11 +97,11 @@ func (c *deployCommand) preRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.args.ServiceOptions.TLSEnabled {
-		if len(c.args.Hosts) == 0 {
+		if len(c.args.ServiceOptions.Hosts) == 0 {
 			return fmt.Errorf("host must be set when using TLS")
 		}
 
-		if !slices.Contains(c.args.PathPrefixes, "/") {
+		if !slices.Contains(c.args.ServiceOptions.PathPrefixes, "/") {
 			return fmt.Errorf("TLS settings must be specified on the root path service")
 		}
 	}

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -27,7 +27,7 @@ func newDeployCommand() *deployCommand {
 		ValidArgs: []string{"service"},
 	}
 
-	deployCommand.cmd.Flags().StringVar(&deployCommand.args.TargetURL, "target", "", "Target host to deploy")
+	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.TargetURLs, "target", []string{}, "Target host(s) to deploy")
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.Hosts, "host", []string{}, "Host(s) to serve this target on (empty for wildcard)")
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.PathPrefixes, "path-prefix", []string{}, "Deploy the service below the specified path(s)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.StripPrefix, "strip-path-prefix", true, "With --path-prefix, strip prefix from request before forwarding")

--- a/internal/cmd/rollout_deploy.go
+++ b/internal/cmd/rollout_deploy.go
@@ -22,7 +22,7 @@ func newRolloutDeployCommand() *rolloutDeployCommand {
 		ValidArgs: []string{"service"},
 	}
 
-	rolloutDeployCommand.cmd.Flags().StringVar(&rolloutDeployCommand.args.TargetURL, "target", "", "Target host to deploy")
+	rolloutDeployCommand.cmd.Flags().StringSliceVar(&rolloutDeployCommand.args.TargetURLs, "target", []string{}, "Target host(s) to deploy")
 	rolloutDeployCommand.cmd.Flags().DurationVar(&rolloutDeployCommand.args.DeployTimeout, "deploy-timeout", server.DefaultDeployTimeout, "Maximum time to wait for the new target to become healthy")
 	rolloutDeployCommand.cmd.Flags().DurationVar(&rolloutDeployCommand.args.DrainTimeout, "drain-timeout", server.DefaultDrainTimeout, "Maximum time to allow existing connections to drain before removing old target")
 

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -19,8 +19,6 @@ type CommandHandler struct {
 type DeployArgs struct {
 	Service        string
 	TargetURLs     []string
-	Hosts          []string
-	PathPrefixes   []string
 	DeployTimeout  time.Duration
 	DrainTimeout   time.Duration
 	ServiceOptions ServiceOptions
@@ -115,7 +113,7 @@ func (h *CommandHandler) Close() error {
 }
 
 func (h *CommandHandler) Deploy(args DeployArgs, reply *bool) error {
-	return h.router.DeployService(args.Service, args.Hosts, args.PathPrefixes, args.TargetURLs, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
+	return h.router.DeployService(args.Service, args.TargetURLs, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
 }
 
 func (h *CommandHandler) Pause(args PauseArgs, reply *bool) error {

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -18,7 +18,7 @@ type CommandHandler struct {
 
 type DeployArgs struct {
 	Service        string
-	TargetURL      string
+	TargetURLs     []string
 	Hosts          []string
 	PathPrefixes   []string
 	DeployTimeout  time.Duration
@@ -49,7 +49,7 @@ type RemoveArgs struct {
 
 type RolloutDeployArgs struct {
 	Service       string
-	TargetURL     string
+	TargetURLs    []string
 	DeployTimeout time.Duration
 	DrainTimeout  time.Duration
 }
@@ -115,7 +115,7 @@ func (h *CommandHandler) Close() error {
 }
 
 func (h *CommandHandler) Deploy(args DeployArgs, reply *bool) error {
-	return h.router.SetServiceTarget(args.Service, args.Hosts, args.PathPrefixes, args.TargetURL, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
+	return h.router.DeployService(args.Service, args.Hosts, args.PathPrefixes, args.TargetURLs, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
 }
 
 func (h *CommandHandler) Pause(args PauseArgs, reply *bool) error {
@@ -141,7 +141,7 @@ func (h *CommandHandler) List(args bool, reply *ListResponse) error {
 }
 
 func (h *CommandHandler) RolloutDeploy(args RolloutDeployArgs, reply *bool) error {
-	return h.router.SetRolloutTarget(args.Service, args.TargetURL, args.DeployTimeout, args.DrainTimeout)
+	return h.router.SetRolloutTargets(args.Service, args.TargetURLs, args.DeployTimeout, args.DrainTimeout)
 }
 
 func (h *CommandHandler) RolloutSet(args RolloutSetArgs, reply *bool) error {

--- a/internal/server/health_check.go
+++ b/internal/server/health_check.go
@@ -109,10 +109,8 @@ func (hc *HealthCheck) check() {
 }
 
 func (hc *HealthCheck) reportResult(success bool, err error) {
-	if success {
-		slog.Info("Healthcheck succeeded")
-	} else {
-		slog.Info("Healthcheck failed", "error", err)
+	if !success {
+		slog.Info("Healthcheck failed", "url", hc.endpoint.String(), "error", err)
 	}
 
 	hc.consumer.HealthCheckCompleted(success)

--- a/internal/server/load_balancer.go
+++ b/internal/server/load_balancer.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var ErrorNoHealthyTargets = errors.New("no healthy targets")
+
+type TargetList []*Target
+
+func NewTargetList(targetNames []string, options TargetOptions) (TargetList, error) {
+	targets := TargetList{}
+
+	for _, name := range targetNames {
+		target, err := NewTarget(name, options)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
+	}
+
+	return targets, nil
+}
+
+func (tl TargetList) Names() []string {
+	names := []string{}
+	for _, target := range tl {
+		names = append(names, target.Target())
+	}
+	return names
+}
+
+func (tl TargetList) Dispose() {
+	for _, target := range tl {
+		target.Close()
+	}
+}
+
+type LoadBalancer struct {
+	healthy TargetList
+	all     TargetList
+	index   int
+	lock    sync.Mutex
+}
+
+func NewLoadBalancer(targets TargetList) *LoadBalancer {
+	lb := &LoadBalancer{
+		healthy: TargetList{},
+		all:     targets,
+	}
+
+	lb.beginHealthChecks()
+	return lb
+}
+
+func (lb *LoadBalancer) Targets() TargetList {
+	lb.lock.Lock()
+
+	defer lb.lock.Unlock()
+	return lb.all
+}
+
+func (lb *LoadBalancer) WaitUntilHealthy(timeout time.Duration) error {
+	var wg sync.WaitGroup
+	var failed atomic.Bool
+
+	wg.Add(len(lb.Targets()))
+
+	for _, target := range lb.Targets() {
+		go func() {
+			if !target.WaitUntilHealthy(timeout) {
+				slog.Info("Target failed to become healthy", "target", target.Target())
+				failed.Store(true)
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	if failed.Load() {
+		return fmt.Errorf("%w (%s)", ErrorTargetFailedToBecomeHealthy, timeout)
+	}
+
+	return nil
+}
+
+func (lb *LoadBalancer) MarkAllHealthy() {
+	for _, target := range lb.Targets() {
+		target.updateState(TargetStateHealthy)
+	}
+	lb.updateHealthyTargets()
+}
+
+func (lb *LoadBalancer) Dispose() {
+	lb.lock.Lock()
+	defer lb.lock.Unlock()
+
+	lb.all.Dispose()
+}
+
+func (lb *LoadBalancer) DrainAll(timeout time.Duration) {
+	var wg sync.WaitGroup
+	wg.Add(len(lb.all))
+
+	for _, target := range lb.all {
+		go func() {
+			target.Drain(timeout)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func (lb *LoadBalancer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	target, req, err := lb.claimTarget(r)
+	if err != nil {
+		SetErrorResponse(w, r, http.StatusServiceUnavailable, nil)
+		return
+	}
+
+	target.SendRequest(w, req)
+}
+
+// TargetStateConsumer
+
+func (lb *LoadBalancer) TargetStateChanged(target *Target) {
+	lb.updateHealthyTargets()
+}
+
+// Private
+
+func (lb *LoadBalancer) claimTarget(req *http.Request) (*Target, *http.Request, error) {
+	lb.lock.Lock()
+	defer lb.lock.Unlock()
+
+	target := lb.nextTarget()
+	if target == nil {
+		return nil, nil, ErrorNoHealthyTargets
+	}
+
+	req, err := target.StartRequest(req)
+	return target, req, err
+}
+
+func (lb *LoadBalancer) nextTarget() *Target {
+	if len(lb.healthy) == 0 {
+		return nil
+	}
+
+	lb.index = (lb.index + 1) % len(lb.healthy)
+	return lb.healthy[lb.index]
+}
+
+func (lb *LoadBalancer) beginHealthChecks() {
+	for _, target := range lb.all {
+		target.BeginHealthChecks(lb)
+	}
+}
+
+func (lb *LoadBalancer) updateHealthyTargets() {
+	lb.lock.Lock()
+	defer lb.lock.Unlock()
+
+	lb.healthy = TargetList{}
+	for _, target := range lb.all {
+		if target.State() == TargetStateHealthy {
+			lb.healthy = append(lb.healthy, target)
+		}
+	}
+}

--- a/internal/server/load_balancer.go
+++ b/internal/server/load_balancer.go
@@ -38,7 +38,7 @@ func (tl TargetList) Names() []string {
 
 func (tl TargetList) Dispose() {
 	for _, target := range tl {
-		target.Close()
+		target.Dispose()
 	}
 }
 
@@ -61,8 +61,8 @@ func NewLoadBalancer(targets TargetList) *LoadBalancer {
 
 func (lb *LoadBalancer) Targets() TargetList {
 	lb.lock.Lock()
-
 	defer lb.lock.Unlock()
+
 	return lb.all
 }
 

--- a/internal/server/load_balancer_test.go
+++ b/internal/server/load_balancer_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTargetList_NewTargetListIllegalNames(t *testing.T) {
+	_, err := NewTargetList([]string{"", "_", "/"}, TargetOptions{})
+	assert.Error(t, err, ErrorInvalidHostPattern)
+}
+
+func TestTargetList_Names(t *testing.T) {
+	tl, err := NewTargetList([]string{"one", "two", "three"}, TargetOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"one", "two", "three"}, tl.Names())
+}
+
+func TestLoadBalancer_Targets(t *testing.T) {
+	tl, err := NewTargetList([]string{"one", "two", "three"}, defaultTargetOptions)
+	require.NoError(t, err)
+
+	lb := NewLoadBalancer(tl)
+	defer lb.Dispose()
+
+	assert.Equal(t, []string{"one", "two", "three"}, lb.Targets().Names())
+}
+
+func TestLoadBalancer_WaitUntilHealthy(t *testing.T) {
+	lb := testLoadBalancerWithHandlers(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+	require.Error(t, lb.WaitUntilHealthy(time.Millisecond*5), ErrorTargetFailedToBecomeHealthy)
+
+	lb = testLoadBalancerWithHandlers(t,
+		func(w http.ResponseWriter, r *http.Request) {},
+		func(w http.ResponseWriter, r *http.Request) {},
+	)
+	require.NoError(t, lb.WaitUntilHealthy(time.Second))
+}
+
+func TestLoadBalancer_ServeHTTP(t *testing.T) {
+	lb := testLoadBalancerWithHandlers(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("one"))
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("two"))
+		},
+	)
+	require.NoError(t, lb.WaitUntilHealthy(time.Second))
+
+	bodies := []string{}
+	for i := 0; i <= 4; i++ {
+		r := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		lb.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		bodies = append(bodies, w.Body.String())
+	}
+
+	assert.Contains(t, bodies, "one")
+	assert.Contains(t, bodies, "two")
+}
+
+// Helpers
+
+func testLoadBalancerWithHandlers(t *testing.T, handlers ...http.HandlerFunc) *LoadBalancer {
+	targets := []string{}
+	for _, h := range handlers {
+		targets = append(targets, testTarget(t, h).Target())
+	}
+
+	tl, err := NewTargetList(targets, defaultTargetOptions)
+	require.NoError(t, err)
+
+	lb := NewLoadBalancer(tl)
+	t.Cleanup(lb.Dispose)
+
+	return lb
+}

--- a/internal/server/load_balancer_test.go
+++ b/internal/server/load_balancer_test.go
@@ -62,7 +62,7 @@ func TestLoadBalancer_ServeHTTP(t *testing.T) {
 	require.NoError(t, lb.WaitUntilHealthy(time.Second))
 
 	bodies := []string{}
-	for i := 0; i <= 4; i++ {
+	for range 4 {
 		r := httptest.NewRequest("GET", "/", nil)
 		w := httptest.NewRecorder()
 

--- a/internal/server/rollout_controller_test.go
+++ b/internal/server/rollout_controller_test.go
@@ -22,7 +22,7 @@ func TestRolloutController_PercentageSplit(t *testing.T) {
 	rc := NewRolloutController(60, []string{})
 
 	usedRolloutGroup := 0
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		req := &http.Request{Header: http.Header{"Cookie": []string{fmt.Sprintf("kamal-rollout=%05d", i)}}}
 		if rc.RequestUsesRolloutGroup(req) {
 			usedRolloutGroup++
@@ -38,7 +38,7 @@ func TestRolloutController_AllowListAndPercentageTogether(t *testing.T) {
 	rc := NewRolloutController(10, []string{"00001", "00002"})
 
 	usedRolloutGroup := 0
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		req := &http.Request{Header: http.Header{"Cookie": []string{fmt.Sprintf("kamal-rollout=%05d", i)}}}
 		if rc.RequestUsesRolloutGroup(req) {
 			usedRolloutGroup++

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -105,10 +105,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	service.ServeHTTP(w, req)
 }
 
-func (r *Router) DeployService(name string, targetURLs []string,
-	options ServiceOptions, targetOptions TargetOptions,
-	deployTimeout time.Duration, drainTimeout time.Duration,
-) error {
+func (r *Router) DeployService(name string, targetURLs []string, options ServiceOptions, targetOptions TargetOptions, deployTimeout time.Duration, drainTimeout time.Duration) error {
 	service, err := r.findOrCreateService(name, options, targetOptions)
 	if err != nil {
 		return err

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -40,7 +40,7 @@ func TestRouter_DeployServiceMultipleTargets(t *testing.T) {
 	require.NoError(t, router.DeployService("service1", []string{firstTarget, secondTarget}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	bodies := []string{}
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		statusCode, body := sendGETRequest(router, "http://example.com/")
 		assert.Equal(t, http.StatusOK, statusCode)
 		bodies = append(bodies, body)

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -20,11 +20,11 @@ func TestRouter_Empty(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, statusCode)
 }
 
-func TestRouter_ActiveServiceForHost(t *testing.T) {
+func TestRouter_DeployService(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
@@ -32,11 +32,29 @@ func TestRouter_ActiveServiceForHost(t *testing.T) {
 	assert.Equal(t, "first", body)
 }
 
+func TestRouter_DeployServiceMultipleTargets(t *testing.T) {
+	router := testRouter(t)
+	_, firstTarget := testBackend(t, "first", http.StatusOK)
+	_, secondTarget := testBackend(t, "second", http.StatusOK)
+
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{firstTarget, secondTarget}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+
+	bodies := []string{}
+	for i := 0; i < 4; i++ {
+		statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
+		assert.Equal(t, http.StatusOK, statusCode)
+		bodies = append(bodies, body)
+	}
+
+	assert.Contains(t, bodies, "first")
+	assert.Contains(t, bodies, "second")
+}
+
 func TestRouter_Removing(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", defaultEmptyHosts, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -47,11 +65,11 @@ func TestRouter_Removing(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, statusCode)
 }
 
-func TestRouter_ActiveServiceForMultipleHosts(t *testing.T) {
+func TestRouter_DeployServiceMultipleHosts(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"1.example.com", "2.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"1.example.com", "2.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -69,9 +87,9 @@ func TestRouter_UpdatingHostsOfActiveService(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"1.example.com", "2.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"1.example.com", "2.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"3.example.com", "2.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"3.example.com", "2.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendGETRequest(router, "http://1.example.com/")
 	assert.Equal(t, http.StatusNotFound, statusCode)
@@ -85,22 +103,22 @@ func TestRouter_UpdatingHostsOfActiveService(t *testing.T) {
 	assert.Equal(t, "first", body)
 }
 
-func TestRouter_ActiveServiceForUnknownHost(t *testing.T) {
+func TestRouter_DeployServiceUnknownHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendGETRequest(router, "http://other.example.com/")
 
 	assert.Equal(t, http.StatusNotFound, statusCode)
 }
 
-func TestRouter_ActiveServiceForHostContainingPort(t *testing.T) {
+func TestRouter_DeployServiceContainingPort(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com:80/")
 
@@ -108,11 +126,11 @@ func TestRouter_ActiveServiceForHostContainingPort(t *testing.T) {
 	assert.Equal(t, "first", body)
 }
 
-func TestRouter_ActiveServiceWithoutHost(t *testing.T) {
+func TestRouter_DeployServiceWithoutHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", defaultEmptyHosts, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
@@ -125,14 +143,14 @@ func TestRouter_ReplacingActiveService(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://dummy.example.com/")
 
@@ -149,21 +167,21 @@ func TestRouter_UpdatingOptions(t *testing.T) {
 
 	targetOptions.BufferRequests = true
 	targetOptions.MaxRequestBodySize = 10
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusRequestEntityTooLarge, statusCode)
 
 	targetOptions.BufferRequests = false
 	targetOptions.MaxRequestBodySize = 0
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
 	serviceOptions.TLSEnabled = true
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusMovedPermanently, statusCode)
@@ -180,19 +198,19 @@ func TestRouter_DeploymmentsWithErrorsDoNotUpdateService(t *testing.T) {
 		assert.Equal(t, "first", body)
 	}
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	ensureServiceIsHealthy()
 
 	t.Run("custom TLS that is not valid", func(t *testing.T) {
 		serviceOptions := ServiceOptions{TLSEnabled: true, TLSCertificatePath: "not valid", TLSPrivateKeyPath: "not valid"}
-		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, defaultPaths, target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+		require.Error(t, router.DeployService("service1", []string{"example.com"}, defaultPaths, []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 		ensureServiceIsHealthy()
 	})
 
 	t.Run("custom error pages that are not valid", func(t *testing.T) {
 		serviceOptions := ServiceOptions{ErrorPagePath: "not valid"}
-		require.Error(t, router.SetServiceTarget("service1", []string{"example.com"}, defaultPaths, target, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+		require.Error(t, router.DeployService("service1", []string{"example.com"}, defaultPaths, []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 		ensureServiceIsHealthy()
 	})
@@ -202,13 +220,13 @@ func TestRouter_UpdatingPauseStateIndependentlyOfDeployments(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	router.PauseService("service1", time.Second, time.Millisecond*10)
 
 	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusGatewayTimeout, statusCode)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusGatewayTimeout, statusCode)
@@ -224,14 +242,14 @@ func TestRouter_ChangingHostForService(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy2.example.com"}, defaultPaths, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"dummy2.example.com"}, defaultPaths, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://dummy2.example.com/")
 
@@ -247,8 +265,8 @@ func TestRouter_ReusingHost(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"dummy.example.com"}, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	err := router.SetServiceTarget("service12", []string{"dummy.example.com"}, defaultPaths, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	require.NoError(t, router.DeployService("service1", []string{"dummy.example.com"}, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	err := router.DeployService("service12", []string{"dummy.example.com"}, defaultPaths, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 
 	require.Equal(t, ErrorHostInUse, err)
 
@@ -263,8 +281,8 @@ func TestRouter_ReusingEmptyHost(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	err := router.SetServiceTarget("service12", defaultEmptyHosts, defaultPaths, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	require.NoError(t, router.DeployService("service1", defaultEmptyHosts, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	err := router.DeployService("service12", defaultEmptyHosts, defaultPaths, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 
 	require.Equal(t, ErrorHostInUse, err)
 
@@ -278,8 +296,8 @@ func TestRouter_RoutingMultipleHosts(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"s1.example.com"}, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("service2", []string{"s2.example.com"}, defaultPaths, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"s1.example.com"}, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{"s2.example.com"}, defaultPaths, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://s1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -299,9 +317,9 @@ func TestRouter_PathBasedRoutingStripPrefix(t *testing.T) {
 	serviceOptions := defaultServiceOptions
 	serviceOptions.StripPrefix = true
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"example.com"}, defaultPaths, backend, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("service2", []string{"example.com"}, []string{"/app"}, backend, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("service3", []string{"example.com"}, []string{"/api/internal"}, backend, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"example.com"}, defaultPaths, []string{backend}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{"example.com"}, []string{"/app"}, []string{backend}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service3", []string{"example.com"}, []string{"/api/internal"}, []string{backend}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/app/show")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -325,7 +343,7 @@ func TestRouter_PathBasedRoutingStripPrefix(t *testing.T) {
 
 	serviceOptions.StripPrefix = false
 
-	require.NoError(t, router.SetServiceTarget("service2", []string{"example.com"}, []string{"/app"}, backend, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{"example.com"}, []string{"/app"}, []string{backend}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://example.com/app")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -337,8 +355,8 @@ func TestRouter_PathBasedRoutingWithHosts(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"example.com"}, []string{"/first"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("service2", []string{"example.com"}, []string{"/second"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"example.com"}, []string{"/first"}, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{"example.com"}, []string{"/second"}, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/first")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -361,9 +379,9 @@ func TestRouter_PathBasedRoutingWithDefaultHost(t *testing.T) {
 	_, second := testBackend(t, "second", http.StatusOK)
 	_, third := testBackend(t, "third", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, []string{"/first"}, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("service2", defaultEmptyHosts, []string{"/second"}, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("service3", []string{"third.example.com"}, []string{"/second"}, third, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", defaultEmptyHosts, []string{"/first"}, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", defaultEmptyHosts, []string{"/second"}, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service3", []string{"third.example.com"}, []string{"/second"}, []string{third}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/first")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -386,8 +404,8 @@ func TestRouter_TargetWithoutHostActsAsWildcard(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", []string{"s1.example.com"}, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, defaultPaths, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{"s1.example.com"}, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("default", defaultEmptyHosts, defaultPaths, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://s1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -408,9 +426,9 @@ func TestRouter_TargetsAllowWildcardSubdomains(t *testing.T) {
 	_, second := testBackend(t, "second", http.StatusOK)
 	_, fallback := testBackend(t, "fallback", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("first", []string{"*.first.example.com"}, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("second", []string{"*.second.example.com"}, defaultPaths, second, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("fallback", defaultEmptyHosts, defaultPaths, fallback, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("first", []string{"*.first.example.com"}, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("second", []string{"*.second.example.com"}, defaultPaths, []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("fallback", defaultEmptyHosts, defaultPaths, []string{fallback}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://app.first.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -429,7 +447,7 @@ func TestRouter_WildcardDomainsCannotBeUsedWithAutomaticTLS(t *testing.T) {
 	router := testRouter(t)
 	_, first := testBackend(t, "first", http.StatusOK)
 
-	err := router.SetServiceTarget("first", []string{"first.example.com", "*.first.example.com"}, defaultPaths, first, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	err := router.DeployService("first", []string{"first.example.com", "*.first.example.com"}, defaultPaths, []string{first}, ServiceOptions{TLSEnabled: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 	require.Equal(t, ErrorAutomaticTLSDoesNotSupportWildcards, err)
 }
 
@@ -437,7 +455,7 @@ func TestRouter_ServiceFailingToBecomeHealthy(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "", http.StatusInternalServerError)
 
-	err := router.SetServiceTarget("example", []string{"example.com"}, defaultPaths, target, defaultServiceOptions, defaultTargetOptions, time.Millisecond*20, DefaultDrainTimeout)
+	err := router.DeployService("example", []string{"example.com"}, defaultPaths, []string{target}, defaultServiceOptions, defaultTargetOptions, time.Millisecond*20, DefaultDrainTimeout)
 	assert.ErrorIs(t, err, ErrorTargetFailedToBecomeHealthy)
 
 	statusCode, _ := sendGETRequest(router, "http://example.com/")
@@ -450,8 +468,8 @@ func TestRouter_EnablingRollout(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.SetServiceTarget("service1", defaultEmptyHosts, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetRolloutTarget("service1", second, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", defaultEmptyHosts, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetRolloutTargets("service1", []string{second}, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	checkResponse := func(expected string) {
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
@@ -481,9 +499,9 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 	_, third := testBackend(t, "third", http.StatusOK)
 
 	router := NewRouter(statePath)
-	require.NoError(t, router.SetServiceTarget("default", defaultEmptyHosts, defaultPaths, first, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("other1", []string{"other.example.com"}, defaultPaths, second, ServiceOptions{TLSEnabled: true, TLSRedirect: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetServiceTarget("other2", []string{"other.example.com"}, []string{"/api"}, third, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("default", defaultEmptyHosts, defaultPaths, []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("other1", []string{"other.example.com"}, defaultPaths, []string{second}, ServiceOptions{TLSEnabled: true, TLSRedirect: true}, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("other2", []string{"other.example.com"}, []string{"/api"}, []string{third}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://something.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -24,7 +24,7 @@ func TestServer_Deploying(t *testing.T) {
 func testDeployTarget(t *testing.T, target *Target, server *Server) {
 	var result bool
 	err := server.commandHandler.Deploy(DeployArgs{
-		TargetURL:      target.Target(),
+		TargetURLs:     []string{target.Target()},
 		DeployTimeout:  DefaultDeployTimeout,
 		DrainTimeout:   DefaultDrainTimeout,
 		ServiceOptions: defaultServiceOptions,

--- a/internal/server/service_map.go
+++ b/internal/server/service_map.go
@@ -55,12 +55,9 @@ func (m *ServiceMap) All() iter.Seq2[string, *Service] {
 	}
 }
 
-func (m *ServiceMap) CheckAvailability(name string, hosts []string, pathPrefixes []string) *Service {
-	pathPrefixes = NormalizePathPrefixes(pathPrefixes)
-	hosts = NormalizeHosts(hosts)
-
-	for _, host := range hosts {
-		for _, pathPrefix := range pathPrefixes {
+func (m *ServiceMap) CheckAvailability(name string, options ServiceOptions) *Service {
+	for _, host := range options.Hosts {
+		for _, pathPrefix := range options.PathPrefixes {
 			bindings := m.requestServiceMap[host]
 			for _, binding := range bindings {
 				if pathPrefix == binding.pathPrefix && binding.service.name != name {
@@ -129,8 +126,8 @@ func (m *ServiceMap) updateRequestServiceMap() {
 	requestServiceMap := requestServiceMap{}
 
 	for _, service := range m.services {
-		for _, host := range service.hosts {
-			for _, pathPrefix := range service.pathPrefixes {
+		for _, host := range service.options.Hosts {
+			for _, pathPrefix := range service.options.PathPrefixes {
 				bindings := requestServiceMap[host]
 				if bindings == nil {
 					bindings = []*pathBinding{}
@@ -153,8 +150,8 @@ func (m *ServiceMap) syncTLSOptionsFromRootDomain() {
 	for _, service := range m.services {
 		if !service.servesRootPath() {
 			host := ""
-			if len(service.hosts) > 0 {
-				host = service.hosts[0]
+			if len(service.options.Hosts) > 0 {
+				host = service.options.Hosts[0]
 			}
 
 			rootService := m.ServiceForHost(host)

--- a/internal/server/service_map_test.go
+++ b/internal/server/service_map_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestServiceMap_ServiceForHost(t *testing.T) {
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{"example.com"}}))
-	sm.Set(normalizedService(&Service{name: "2", hosts: []string{"app.example.com"}}))
-	sm.Set(normalizedService(&Service{name: "3", hosts: []string{"api.example.com"}}))
-	sm.Set(normalizedService(&Service{name: "4", hosts: []string{"*.example.com"}}))
-	sm.Set(normalizedService(&Service{name: "5"}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}})})
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}})})
+	sm.Set(&Service{name: "3", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"api.example.com"}})})
+	sm.Set(&Service{name: "4", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"*.example.com"}})})
+	sm.Set(&Service{name: "5", options: normalizedServiceOptions(defaultServiceOptions)})
 
 	assert.Equal(t, "1", sm.ServiceForHost("example.com").name)
 	assert.Equal(t, "2", sm.ServiceForHost("app.example.com").name)
@@ -25,19 +25,19 @@ func TestServiceMap_ServiceForHost(t *testing.T) {
 	assert.Equal(t, "5", sm.ServiceForHost("other.com").name)
 
 	sm = NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{"example.com"}}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}})})
 
 	assert.Nil(t, sm.ServiceForHost("app.example.com"))
 }
 
 func TestServiceMap_ServiceForRequest(t *testing.T) {
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{"example.com"}}))
-	sm.Set(normalizedService(&Service{name: "2", hosts: []string{"example.com"}, pathPrefixes: []string{"/api"}}))
-	sm.Set(normalizedService(&Service{name: "3", hosts: []string{"example.com"}, pathPrefixes: []string{"/api/special"}}))
-	sm.Set(normalizedService(&Service{name: "4", hosts: []string{"other.example.com"}, pathPrefixes: []string{"/api"}}))
-	sm.Set(normalizedService(&Service{name: "5", pathPrefixes: []string{"/api"}}))
-	sm.Set(normalizedService(&Service{name: "6"}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}})})
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}, PathPrefixes: []string{"/api"}})})
+	sm.Set(&Service{name: "3", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}, PathPrefixes: []string{"/api/special"}})})
+	sm.Set(&Service{name: "4", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"other.example.com"}, PathPrefixes: []string{"/api"}})})
+	sm.Set(&Service{name: "5", options: normalizedServiceOptions(ServiceOptions{PathPrefixes: []string{"/api"}})})
+	sm.Set(&Service{name: "6", options: normalizedServiceOptions(defaultServiceOptions)})
 
 	checkService := func(expected string, url string) {
 		servivce, _ := sm.ServiceForRequest(httptest.NewRequest(http.MethodGet, url, nil))
@@ -56,32 +56,27 @@ func TestServiceMap_ServiceForRequest(t *testing.T) {
 
 func TestServiceMap_CheckAvailability(t *testing.T) {
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{"example.com"}}))
-	sm.Set(normalizedService(&Service{name: "2", hosts: []string{"app.example.com"}}))
-	sm.Set(normalizedService(&Service{name: "3", hosts: []string{"app.example.com"}, pathPrefixes: []string{"/api"}}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}})})
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}})})
+	sm.Set(&Service{name: "3", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}, PathPrefixes: []string{"/api"}})})
 
-	assert.Nil(t, sm.CheckAvailability("2", []string{"app.example.com"}, defaultPaths))
+	assert.Nil(t, sm.CheckAvailability("2", normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}})))
 
-	assert.Nil(t, sm.CheckAvailability("4", []string{"api.example.com"}, defaultPaths))
-	assert.Nil(t, sm.CheckAvailability("4", []string{""}, defaultPaths))
-	assert.Nil(t, sm.CheckAvailability("4", []string{"app.example.com"}, []string{"/app"}))
-	assert.Nil(t, sm.CheckAvailability("3", []string{"app.example.com"}, []string{"/api"}))
+	assert.Nil(t, sm.CheckAvailability("4", normalizedServiceOptions(ServiceOptions{Hosts: []string{"api.example.com"}})))
+	assert.Nil(t, sm.CheckAvailability("4", normalizedServiceOptions(ServiceOptions{Hosts: []string{""}})))
+	assert.Nil(t, sm.CheckAvailability("4", normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}, PathPrefixes: []string{"/app"}})))
+	assert.Nil(t, sm.CheckAvailability("3", normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}, PathPrefixes: []string{"/api"}})))
 
-	assert.Equal(t, "2", sm.CheckAvailability("4", []string{"app.example.com"}, defaultPaths).name)
-	assert.Equal(t, "3", sm.CheckAvailability("4", []string{"app.example.com"}, []string{"/api"}).name)
+	assert.Equal(t, "2", sm.CheckAvailability("4", normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}})).name)
+	assert.Equal(t, "3", sm.CheckAvailability("4", normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}, PathPrefixes: []string{"/api"}})).name)
 }
 
 func TestServiceMap_SyncingTLSSettingsFromRootPath(t *testing.T) {
-	optionsWithTLS := ServiceOptions{
-		TLSEnabled:  true,
-		TLSRedirect: false,
-	}
-
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{"1.example.com"}, options: optionsWithTLS}))
-	sm.Set(normalizedService(&Service{name: "2", hosts: []string{"1.example.com"}, pathPrefixes: []string{"/api"}}))
-	sm.Set(normalizedService(&Service{name: "3", hosts: []string{"2.example.com"}, options: defaultServiceOptions}))
-	sm.Set(normalizedService(&Service{name: "4", hosts: []string{"2.example.com"}, pathPrefixes: []string{"/api"}}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"1.example.com"}, TLSEnabled: true, TLSRedirect: false})})
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"1.example.com"}, PathPrefixes: []string{"/api"}})})
+	sm.Set(&Service{name: "3", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"2.example.com"}, TLSEnabled: false, TLSRedirect: true})})
+	sm.Set(&Service{name: "4", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"2.example.com"}, PathPrefixes: []string{"/api"}})})
 
 	assert.True(t, sm.Get("1").options.TLSEnabled)
 	assert.False(t, sm.Get("1").options.TLSRedirect)
@@ -101,14 +96,14 @@ func TestServiceMap_SyncingTLSSettingsFromRootPath(t *testing.T) {
 
 func TestServiceMap_CheckHostAvailability_EmptyHostsFirst(t *testing.T) {
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{}}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(defaultServiceOptions)})
 
-	assert.Nil(t, sm.CheckAvailability("2", []string{"app.example.com"}, defaultPaths))
+	assert.Nil(t, sm.CheckAvailability("2", normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}})))
 }
 
 func BenchmarkServiceMap_SingleServiceRouting(b *testing.B) {
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1"}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(defaultServiceOptions)})
 
 	b.Run("exact match", func(b *testing.B) {
 		req := httptest.NewRequest(http.MethodGet, "https://one.example.com/", nil)
@@ -121,9 +116,9 @@ func BenchmarkServiceMap_SingleServiceRouting(b *testing.B) {
 
 func BenchmarkServiceMap_WilcardRouting(b *testing.B) {
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{"one.example.com"}}))
-	sm.Set(normalizedService(&Service{name: "2", hosts: []string{"*.two.example.com"}}))
-	sm.Set(normalizedService(&Service{name: "3"}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"one.example.com"}})})
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"*.two.example.com"}})})
+	sm.Set(&Service{name: "3", options: normalizedServiceOptions(defaultServiceOptions)})
 
 	b.Run("exact match", func(b *testing.B) {
 		req := httptest.NewRequest(http.MethodGet, "https://one.example.com/", nil)
@@ -152,10 +147,10 @@ func BenchmarkServiceMap_WilcardRouting(b *testing.B) {
 
 func BenchmarkServiceMap_HostAndPathBasedRouting(b *testing.B) {
 	sm := NewServiceMap()
-	sm.Set(normalizedService(&Service{name: "1", hosts: []string{"one.example.com"}, pathPrefixes: []string{"/api"}}))
-	sm.Set(normalizedService(&Service{name: "2", hosts: []string{"one.example.com"}}))
-	sm.Set(normalizedService(&Service{name: "3", pathPrefixes: []string{"/app"}}))
-	sm.Set(normalizedService(&Service{name: "4"}))
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"one.example.com"}, PathPrefixes: []string{"/api"}})})
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"one.example.com"}})})
+	sm.Set(&Service{name: "3", options: normalizedServiceOptions(ServiceOptions{PathPrefixes: []string{"/app"}})})
+	sm.Set(&Service{name: "4", options: normalizedServiceOptions(defaultServiceOptions)})
 
 	b.Run("host and path match", func(b *testing.B) {
 		req := httptest.NewRequest(http.MethodGet, "https://one.example.com/api", nil)
@@ -192,9 +187,7 @@ func BenchmarkServiceMap_HostAndPathBasedRouting(b *testing.B) {
 
 // Helpers
 
-func normalizedService(s *Service) *Service {
-	s.hosts = NormalizeHosts(s.hosts)
-	s.pathPrefixes = NormalizePathPrefixes(s.pathPrefixes)
-
-	return s
+func normalizedServiceOptions(so ServiceOptions) ServiceOptions {
+	so.Normalize()
+	return so
 }

--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -33,6 +33,7 @@ const (
 	TargetStateAdding TargetState = iota
 	TargetStateDraining
 	TargetStateHealthy
+	TargetStateUnhealthy
 )
 
 func (ts TargetState) String() string {
@@ -45,6 +46,10 @@ func (ts TargetState) String() string {
 		return "healthy"
 	}
 	return ""
+}
+
+type TargetStateConsumer interface {
+	TargetStateChanged(*Target)
 }
 
 type inflightRequest struct {
@@ -67,6 +72,10 @@ type TargetOptions struct {
 	ForwardHeaders      bool              `json:"forward_headers"`
 }
 
+func (to *TargetOptions) IsHealthCheckRequest(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == to.HealthCheckConfig.Path
+}
+
 func (to *TargetOptions) canonicalizeLogHeaders() {
 	for i, header := range to.LogRequestHeaders {
 		to.LogRequestHeaders[i] = http.CanonicalHeaderKey(header)
@@ -86,6 +95,7 @@ type Target struct {
 	inflightLock sync.Mutex
 
 	healthcheck   *HealthCheck
+	stateConsumer TargetStateConsumer
 	becameHealthy chan (bool)
 }
 
@@ -121,6 +131,17 @@ func (t *Target) Target() string {
 	return t.targetURL.Host
 }
 
+func (t *Target) State() TargetState {
+	t.inflightLock.Lock()
+	defer t.inflightLock.Unlock()
+
+	return t.state
+}
+
+func (t *Target) Close() {
+	t.stopHealthChecks()
+}
+
 func (t *Target) StartRequest(req *http.Request) (*http.Request, error) {
 	t.inflightLock.Lock()
 	defer t.inflightLock.Unlock()
@@ -148,10 +169,6 @@ func (t *Target) SendRequest(w http.ResponseWriter, req *http.Request) {
 
 	tw := newTargetResponseWriter(w, inflightRequest)
 	t.proxyHandler.ServeHTTP(tw, req)
-}
-
-func (t *Target) IsHealthCheckRequest(r *http.Request) bool {
-	return r.Method == http.MethodGet && r.URL.Path == t.options.HealthCheckConfig.Path
 }
 
 func (t *Target) Drain(timeout time.Duration) {
@@ -186,8 +203,10 @@ WAIT_FOR_REQUESTS_TO_COMPLETE:
 	}
 }
 
-func (t *Target) BeginHealthChecks() {
+func (t *Target) BeginHealthChecks(stateConsumer TargetStateConsumer) {
+	t.stateConsumer = stateConsumer
 	t.becameHealthy = make(chan bool)
+
 	t.healthcheck = NewHealthCheck(t,
 		t.targetURL.JoinPath(t.options.HealthCheckConfig.Path),
 		t.options.HealthCheckConfig.Interval,
@@ -195,7 +214,7 @@ func (t *Target) BeginHealthChecks() {
 	)
 }
 
-func (t *Target) StopHealthChecks() {
+func (t *Target) stopHealthChecks() {
 	if t.healthcheck != nil {
 		t.healthcheck.Close()
 		t.healthcheck = nil
@@ -203,12 +222,11 @@ func (t *Target) StopHealthChecks() {
 }
 
 func (t *Target) WaitUntilHealthy(timeout time.Duration) bool {
-	t.BeginHealthChecks()
-	defer t.StopHealthChecks()
-
 	select {
 	case <-time.After(timeout):
+		t.stopHealthChecks()
 		return false
+
 	case <-t.becameHealthy:
 		return true
 	}
@@ -217,15 +235,35 @@ func (t *Target) WaitUntilHealthy(timeout time.Duration) bool {
 // HealthCheckConsumer
 
 func (t *Target) HealthCheckCompleted(success bool) {
-	t.inflightLock.Lock()
-	defer t.inflightLock.Unlock()
+	previousState := t.state
+	newState := t.state
 
-	if success && t.state == TargetStateAdding {
-		t.state = TargetStateHealthy
-		close(t.becameHealthy)
+	t.withInflightLock(func() {
+		switch success {
+		case true:
+			switch t.state {
+			case TargetStateAdding:
+				t.state = TargetStateHealthy
+				close(t.becameHealthy)
+			default:
+				t.state = TargetStateHealthy
+			}
+		case false:
+			switch t.state {
+			case TargetStateHealthy:
+				t.state = TargetStateUnhealthy
+			}
+		}
+		newState = t.state
+	})
+
+	if newState != previousState {
+		slog.Info("Target health updated", "target", t.Target(), "state", newState.String(), "was", previousState.String())
+
+		if t.stateConsumer != nil {
+			t.stateConsumer.TargetStateChanged(t)
+		}
 	}
-
-	slog.Info("Target health updated", "target", t.Target(), "success", success, "state", t.state.String())
 }
 
 // Private
@@ -388,6 +426,13 @@ func (t *Target) pendingRequestsToCancel() inflightMap {
 	}
 
 	return result
+}
+
+func (t *Target) withInflightLock(fn func()) {
+	t.inflightLock.Lock()
+	defer t.inflightLock.Unlock()
+
+	fn()
 }
 
 func parseTargetURL(targetURL string) (*url.URL, error) {

--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -138,7 +138,7 @@ func (t *Target) State() TargetState {
 	return t.state
 }
 
-func (t *Target) Close() {
+func (t *Target) Dispose() {
 	t.stopHealthChecks()
 }
 

--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -321,7 +321,7 @@ func TestTarget_DrainRequestsThatCompleteWithinTimeout(t *testing.T) {
 		started.Done()
 	})
 
-	for i := 0; i < n; i++ {
+	for range n {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 		go testServeRequestWithTarget(t, target, w, req)
@@ -342,7 +342,7 @@ func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {
 
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
 		started.Done()
-		for i := 0; i < 500; i++ {
+		for range 500 {
 			time.Sleep(time.Millisecond * 100)
 			if r.Context().Err() != nil { // Request was cancelled by client
 				return
@@ -351,7 +351,7 @@ func TestTarget_DrainRequestsThatNeedToBeCancelled(t *testing.T) {
 		served++
 	})
 
-	for i := 0; i < n; i++ {
+	for range n {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 		go func() {

--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -277,11 +277,11 @@ func TestTarget_UnparseableQueryParametersArePreserved(t *testing.T) {
 func TestTarget_IsHealthCheckRequest(t *testing.T) {
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {})
 
-	assert.True(t, target.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up", nil)))
-	assert.True(t, target.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up?one=two", nil)))
+	assert.True(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up", nil)))
+	assert.True(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up?one=two", nil)))
 
-	assert.False(t, target.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up/other", nil)))
-	assert.False(t, target.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/health", nil)))
+	assert.False(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up/other", nil)))
+	assert.False(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/health", nil)))
 }
 
 func TestTarget_AddedTargetBecomesHealthy(t *testing.T) {
@@ -289,7 +289,7 @@ func TestTarget_AddedTargetBecomesHealthy(t *testing.T) {
 		w.Write([]byte("ok"))
 	})
 
-	target.BeginHealthChecks()
+	target.BeginHealthChecks(nil)
 
 	require.True(t, target.WaitUntilHealthy(time.Second))
 	require.Equal(t, TargetStateHealthy, target.state)

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -6,12 +6,13 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 var (
-	defaultHealthCheckConfig = HealthCheckConfig{Path: DefaultHealthCheckPath, Interval: DefaultHealthCheckInterval, Timeout: DefaultHealthCheckTimeout}
+	defaultHealthCheckConfig = HealthCheckConfig{Path: DefaultHealthCheckPath, Interval: DefaultHealthCheckInterval, Timeout: time.Second * 5}
 	defaultEmptyHosts        = []string{}
 	defaultPaths             = []string{rootPath}
 	defaultServiceOptions    = ServiceOptions{TLSRedirect: true}


### PR DESCRIPTION
Adds the ability to deploy multiple targets per service. Requests are routed to the targets on a round-robin basis.

For a multi-target deployment to succeed, all of the targets must become healthy within the timeout. If any fails to do so, the deployment fails, and the previous set of targets is kept. After deployment, we continue to monitor the health of each target, moving them in and out of the healthy pool as necessary so that we avoid routing requests onto unhealthy targets.

As part of this change we also refactor some of a service's settings into its `ServiceOptions`, to provide a better separation between the service itself and the options that it's been configured with.

Closes #15