### PR TITLE
Allow splitting reads/writes when load balancing

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -28,6 +28,7 @@ func newDeployCommand() *deployCommand {
 	}
 
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.TargetURLs, "target", []string{}, "Target host(s) to deploy")
+	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.ReaderURLs, "read-target", []string{}, "Read-only target host(s) to deploy")
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.ServiceOptions.Hosts, "host", []string{}, "Host(s) to serve this target on (empty for wildcard)")
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.ServiceOptions.PathPrefixes, "path-prefix", []string{}, "Deploy the service below the specified path(s)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.StripPrefix, "strip-path-prefix", true, "With --path-prefix, strip prefix from request before forwarding")
@@ -43,6 +44,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Interval, "health-check-interval", server.DefaultHealthCheckInterval, "Interval between health checks")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Timeout, "health-check-timeout", server.DefaultHealthCheckTimeout, "Time each health check must complete in")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Path, "health-check-path", server.DefaultHealthCheckPath, "Path to check for health")
+	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.ServiceOptions.WriterAffinityTimeout, "writer-affinity-timeout", server.DefaultWriterAffinityTimeout, "Time after a write before read requests will be routed to readers")
 
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.TargetOptions.ResponseTimeout, "target-timeout", server.DefaultTargetTimeout, "Maximum time to wait for the target server to respond when serving requests")
 

--- a/internal/cmd/rollout_deploy.go
+++ b/internal/cmd/rollout_deploy.go
@@ -23,6 +23,7 @@ func newRolloutDeployCommand() *rolloutDeployCommand {
 	}
 
 	rolloutDeployCommand.cmd.Flags().StringSliceVar(&rolloutDeployCommand.args.TargetURLs, "target", []string{}, "Target host(s) to deploy")
+	rolloutDeployCommand.cmd.Flags().StringSliceVar(&rolloutDeployCommand.args.ReaderURLs, "read-target", []string{}, "Read-only target host(s) to deploy")
 	rolloutDeployCommand.cmd.Flags().DurationVar(&rolloutDeployCommand.args.DeployTimeout, "deploy-timeout", server.DefaultDeployTimeout, "Maximum time to wait for the new target to become healthy")
 	rolloutDeployCommand.cmd.Flags().DurationVar(&rolloutDeployCommand.args.DrainTimeout, "drain-timeout", server.DefaultDrainTimeout, "Maximum time to allow existing connections to drain before removing old target")
 

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -19,6 +19,7 @@ type CommandHandler struct {
 type DeployArgs struct {
 	Service        string
 	TargetURLs     []string
+	ReaderURLs     []string
 	DeployTimeout  time.Duration
 	DrainTimeout   time.Duration
 	ServiceOptions ServiceOptions
@@ -48,6 +49,7 @@ type RemoveArgs struct {
 type RolloutDeployArgs struct {
 	Service       string
 	TargetURLs    []string
+	ReaderURLs    []string
 	DeployTimeout time.Duration
 	DrainTimeout  time.Duration
 }
@@ -113,7 +115,7 @@ func (h *CommandHandler) Close() error {
 }
 
 func (h *CommandHandler) Deploy(args DeployArgs, reply *bool) error {
-	return h.router.DeployService(args.Service, args.TargetURLs, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
+	return h.router.DeployService(args.Service, args.TargetURLs, args.ReaderURLs, args.ServiceOptions, args.TargetOptions, args.DeployTimeout, args.DrainTimeout)
 }
 
 func (h *CommandHandler) Pause(args PauseArgs, reply *bool) error {
@@ -139,7 +141,7 @@ func (h *CommandHandler) List(args bool, reply *ListResponse) error {
 }
 
 func (h *CommandHandler) RolloutDeploy(args RolloutDeployArgs, reply *bool) error {
-	return h.router.SetRolloutTargets(args.Service, args.TargetURLs, args.DeployTimeout, args.DrainTimeout)
+	return h.router.SetRolloutTargets(args.Service, args.TargetURLs, args.ReaderURLs, args.DeployTimeout, args.DrainTimeout)
 }
 
 func (h *CommandHandler) RolloutSet(args RolloutSetArgs, reply *bool) error {

--- a/internal/server/health_check.go
+++ b/internal/server/health_check.go
@@ -16,8 +16,8 @@ const (
 )
 
 var (
-	ErrorHealthCheckRequestTimedOut  = errors.New("Request timed out")
-	ErrorHealthCheckUnexpectedStatus = errors.New("Unexpected status")
+	ErrorHealthCheckRequestTimedOut  = errors.New("request timed out")
+	ErrorHealthCheckUnexpectedStatus = errors.New("unexpected status")
 )
 
 type HealthCheckConsumer interface {

--- a/internal/server/load_balancer_test.go
+++ b/internal/server/load_balancer_test.go
@@ -11,22 +11,22 @@ import (
 )
 
 func TestTargetList_NewTargetListIllegalNames(t *testing.T) {
-	_, err := NewTargetList([]string{"", "_", "/"}, TargetOptions{})
+	_, err := NewTargetList([]string{"", "_", "/"}, []string{}, TargetOptions{})
 	assert.Error(t, err, ErrorInvalidHostPattern)
 }
 
 func TestTargetList_Names(t *testing.T) {
-	tl, err := NewTargetList([]string{"one", "two", "three"}, TargetOptions{})
+	tl, err := NewTargetList([]string{"one", "two", "three"}, []string{}, TargetOptions{})
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"one", "two", "three"}, tl.Names())
 }
 
 func TestLoadBalancer_Targets(t *testing.T) {
-	tl, err := NewTargetList([]string{"one", "two", "three"}, defaultTargetOptions)
+	tl, err := NewTargetList([]string{"one", "two", "three"}, []string{}, defaultTargetOptions)
 	require.NoError(t, err)
 
-	lb := NewLoadBalancer(tl)
+	lb := NewLoadBalancer(tl, DefaultWriterAffinityTimeout)
 	defer lb.Dispose()
 
 	assert.Equal(t, []string{"one", "two", "three"}, lb.Targets().Names())
@@ -50,7 +50,7 @@ func TestLoadBalancer_WaitUntilHealthy(t *testing.T) {
 	require.NoError(t, lb.WaitUntilHealthy(time.Second))
 }
 
-func TestLoadBalancer_ServeHTTP(t *testing.T) {
+func TestLoadBalancer_StartRequest(t *testing.T) {
 	lb := testLoadBalancerWithHandlers(t,
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("one"))
@@ -66,7 +66,7 @@ func TestLoadBalancer_ServeHTTP(t *testing.T) {
 		r := httptest.NewRequest("GET", "/", nil)
 		w := httptest.NewRecorder()
 
-		lb.ServeHTTP(w, r)
+		lb.StartRequest(w, r)()
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		bodies = append(bodies, w.Body.String())
@@ -74,6 +74,82 @@ func TestLoadBalancer_ServeHTTP(t *testing.T) {
 
 	assert.Contains(t, bodies, "one")
 	assert.Contains(t, bodies, "two")
+}
+
+func TestLoadBalancer_Readers(t *testing.T) {
+	createLoadBalancer := func(includeReader bool, writerAffinityTimeout time.Duration) *LoadBalancer {
+		writer := testTarget(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("writer"))
+		})
+
+		readers := []string{}
+		if includeReader {
+			reader := testReadOnlyTarget(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("reader"))
+			})
+			readers = []string{reader.Target()}
+		}
+
+		tl, err := NewTargetList([]string{writer.Target()}, readers, defaultTargetOptions)
+		require.NoError(t, err)
+
+		lb := NewLoadBalancer(tl, writerAffinityTimeout)
+		t.Cleanup(lb.Dispose)
+
+		lb.WaitUntilHealthy(time.Second)
+
+		return lb
+	}
+
+	checkResponse := func(lb *LoadBalancer, r *http.Request, expected string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		lb.StartRequest(w, r)()
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, expected, w.Body.String())
+
+		return w
+	}
+
+	t.Run("routing read and write requests", func(t *testing.T) {
+		lb := createLoadBalancer(true, DefaultWriterAffinityTimeout)
+
+		_ = checkResponse(lb, httptest.NewRequest("GET", "/", nil), "reader")
+		_ = checkResponse(lb, httptest.NewRequest("GET", "/", nil), "reader")
+
+		_ = checkResponse(lb, httptest.NewRequest("DELETE", "/", nil), "writer")
+		_ = checkResponse(lb, httptest.NewRequest("PATCH", "/", nil), "writer")
+		_ = checkResponse(lb, httptest.NewRequest("POST", "/", nil), "writer")
+		_ = checkResponse(lb, httptest.NewRequest("PUT", "/", nil), "writer")
+	})
+
+	t.Run("writer affinity", func(t *testing.T) {
+		lb := createLoadBalancer(true, DefaultWriterAffinityTimeout)
+
+		w := checkResponse(lb, httptest.NewRequest("GET", "/", nil), "reader")
+		assert.Empty(t, w.Result().Cookies())
+
+		w = checkResponse(lb, httptest.NewRequest("PUT", "/something", nil), "writer")
+		cookie := w.Result().Cookies()[0]
+		assert.Equal(t, LoadBalancerWriteCookieName, cookie.Name)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(cookie)
+		_ = checkResponse(lb, req, "writer")
+	})
+
+	t.Run("writer affinity not active when no readers", func(t *testing.T) {
+		lb := createLoadBalancer(false, DefaultWriterAffinityTimeout)
+
+		w := checkResponse(lb, httptest.NewRequest("PUT", "/something", nil), "writer")
+		assert.Empty(t, w.Result().Cookies())
+	})
+
+	t.Run("writer affinity not active when the timeout is zero", func(t *testing.T) {
+		lb := createLoadBalancer(true, 0)
+
+		w := checkResponse(lb, httptest.NewRequest("PUT", "/something", nil), "writer")
+		assert.Empty(t, w.Result().Cookies())
+	})
 }
 
 // Helpers
@@ -84,10 +160,10 @@ func testLoadBalancerWithHandlers(t *testing.T, handlers ...http.HandlerFunc) *L
 		targets = append(targets, testTarget(t, h).Target())
 	}
 
-	tl, err := NewTargetList(targets, defaultTargetOptions)
+	tl, err := NewTargetList(targets, []string{}, defaultTargetOptions)
 	require.NoError(t, err)
 
-	lb := NewLoadBalancer(tl)
+	lb := NewLoadBalancer(tl, DefaultWriterAffinityTimeout)
 	t.Cleanup(lb.Dispose)
 
 	return lb

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -105,23 +105,32 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	service.ServeHTTP(w, req)
 }
 
-func (r *Router) DeployService(name string, targetURLs []string, options ServiceOptions, targetOptions TargetOptions, deployTimeout time.Duration, drainTimeout time.Duration) error {
-	service, err := r.findOrCreateService(name, options, targetOptions)
+func (r *Router) DeployService(name string, targetURLs, readerURLs []string, options ServiceOptions, targetOptions TargetOptions, deployTimeout time.Duration, drainTimeout time.Duration) error {
+	options.Normalize()
+	slog.Info("Deploying", "service", name, "targets", targetURLs, "hosts", options.Hosts, "paths", options.PathPrefixes, "tls", options.TLSEnabled)
+
+	lb, err := r.createLoadBalancer(targetURLs, readerURLs, options, targetOptions, deployTimeout)
 	if err != nil {
 		return err
 	}
 
-	slog.Info("Deploying", "service", name, "hosts", options.Hosts, "paths", options.PathPrefixes, "targets", targetURLs, "tls", options.TLSEnabled, "strip", options.StripPrefix)
-	err = r.deployTargetsIntoService(service, TargetSlotActive, targetURLs, deployTimeout, drainTimeout)
+	replaced, err := r.installLoadBalancer(name, TargetSlotActive, lb, options, func() (*Service, error) {
+		return r.createOrUpdateService(name, options, targetOptions)
+	})
 	if err != nil {
 		return err
 	}
 
-	slog.Info("Deployed", "service", name, "hosts", options.Hosts, "paths", options.PathPrefixes, "targets", targetURLs, "tls", options.TLSEnabled, "strip", options.StripPrefix)
+	if replaced != nil {
+		replaced.Dispose()
+		replaced.DrainAll(drainTimeout)
+	}
+
+	slog.Info("Deployed", "service", name, "targets", targetURLs, "hosts", options.Hosts, "paths", options.PathPrefixes, "tls", options.TLSEnabled)
 	return nil
 }
 
-func (r *Router) SetRolloutTargets(name string, targetURLs []string, deployTimeout time.Duration, drainTimeout time.Duration) error {
+func (r *Router) SetRolloutTargets(name string, targetURLs, readerURLs []string, deployTimeout time.Duration, drainTimeout time.Duration) error {
 	service := r.serviceForName(name)
 	if service == nil {
 		return ErrorServiceNotFound
@@ -129,9 +138,21 @@ func (r *Router) SetRolloutTargets(name string, targetURLs []string, deployTimeo
 
 	slog.Info("Deploying for rollout", "service", name, "targets", targetURLs)
 
-	err := r.deployTargetsIntoService(service, TargetSlotRollout, targetURLs, deployTimeout, drainTimeout)
+	lb, err := r.createLoadBalancer(targetURLs, readerURLs, service.options, service.targetOptions, deployTimeout)
 	if err != nil {
 		return err
+	}
+
+	replaced, err := r.installLoadBalancer(name, TargetSlotRollout, lb, service.options, func() (*Service, error) {
+		return service, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if replaced != nil {
+		replaced.Dispose()
+		replaced.DrainAll(drainTimeout)
 	}
 
 	slog.Info("Deployed for rollout", "service", name, "targets", targetURLs)
@@ -261,61 +282,55 @@ func (r *Router) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, e
 
 // Private
 
-func (r *Router) deployTargetsIntoService(service *Service, targetSlot TargetSlot, targetURLs []string, deployTimeout time.Duration, drainTimeout time.Duration) error {
-	tl, err := NewTargetList(targetURLs, service.targetOptions)
-	if err != nil {
-		return err
+func (r *Router) createOrUpdateService(name string, options ServiceOptions, targetOptions TargetOptions) (*Service, error) {
+	service := r.services.Get(name)
+	if service == nil {
+		return NewService(name, options, targetOptions)
 	}
 
-	lb := NewLoadBalancer(tl)
+	err := service.UpdateOptions(options, targetOptions)
+	return service, err
+}
+
+func (r *Router) createLoadBalancer(targetURLs, readerURLs []string, options ServiceOptions, targetOptions TargetOptions, deployTimeout time.Duration) (*LoadBalancer, error) {
+	tl, err := NewTargetList(targetURLs, readerURLs, targetOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	lb := NewLoadBalancer(tl, options.WriterAffinityTimeout)
 	err = lb.WaitUntilHealthy(deployTimeout)
 	if err != nil {
 		lb.Dispose()
-		return err
+		return nil, err
 	}
 
-	replaced := service.UpdateLoadBalancer(lb, targetSlot)
-
-	err = r.installService(service)
-	if err != nil {
-		return err
-	}
-
-	if replaced != nil {
-		replaced.DrainAll(drainTimeout)
-		replaced.Dispose()
-	}
-
-	return nil
+	return lb, nil
 }
 
-func (r *Router) installService(s *Service) error {
+func (r *Router) installLoadBalancer(name string, slot TargetSlot, lb *LoadBalancer, options ServiceOptions, getService func() (*Service, error)) (*LoadBalancer, error) {
 	defer r.saveStateSnapshot()
 
+	var replaced *LoadBalancer
+
 	err := r.withWriteLock(func() error {
-		conflict := r.services.CheckAvailability(s.name, s.options)
+		conflict := r.services.CheckAvailability(name, options)
 		if conflict != nil {
 			slog.Error("Host settings conflict with another service", "service", conflict.name)
 			return ErrorHostInUse
 		}
 
-		r.services.Set(s)
+		service, err := getService()
+		if err != nil {
+			return err
+		}
+
+		replaced = service.UpdateLoadBalancer(lb, slot)
+		r.services.Set(service)
 		return nil
 	})
-	if err != nil {
-		return err
-	}
 
-	return nil
-}
-
-func (r *Router) findOrCreateService(name string, options ServiceOptions, targetOptions TargetOptions) (*Service, error) {
-	service := r.serviceForName(name)
-	if service != nil {
-		return service.CopyWithOptions(options, targetOptions)
-	}
-
-	return NewService(name, options, targetOptions)
+	return replaced, err
 }
 
 func (r *Router) saveStateSnapshot() error {

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -24,7 +24,7 @@ func TestRouter_DeployService(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/")
 
@@ -37,7 +37,7 @@ func TestRouter_DeployServiceMultipleTargets(t *testing.T) {
 	_, firstTarget := testBackend(t, "first", http.StatusOK)
 	_, secondTarget := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{firstTarget, secondTarget}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{firstTarget, secondTarget}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	bodies := []string{}
 	for range 4 {
@@ -54,7 +54,7 @@ func TestRouter_Removing(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -72,7 +72,7 @@ func TestRouter_DeployServiceMultipleHosts(t *testing.T) {
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"1.example.com", "2.example.com"}
 
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -92,10 +92,10 @@ func TestRouter_UpdatingHostsOfActiveService(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"1.example.com", "2.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	serviceOptions.Hosts = []string{"3.example.com", "2.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendGETRequest(router, "http://1.example.com/")
 	assert.Equal(t, http.StatusNotFound, statusCode)
@@ -115,7 +115,7 @@ func TestRouter_DeployServiceUnknownHost(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"dummy.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendGETRequest(router, "http://other.example.com/")
 
@@ -128,7 +128,7 @@ func TestRouter_DeployServiceContainingPort(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"dummy.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com:80/")
 
@@ -140,7 +140,7 @@ func TestRouter_DeployServiceWithoutHost(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
@@ -153,14 +153,14 @@ func TestRouter_ReplacingActiveService(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
-	require.NoError(t, router.DeployService("service1", []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{second}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://dummy.example.com/")
 
@@ -179,28 +179,28 @@ func TestRouter_UpdatingOptions(t *testing.T) {
 	targetOptions.BufferRequests = true
 	targetOptions.MaxRequestBodySize = 10
 
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusRequestEntityTooLarge, statusCode)
 
 	targetOptions.BufferRequests = false
 	targetOptions.MaxRequestBodySize = 0
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "first", body)
 
 	serviceOptions.TLSEnabled = true
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://dummy.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusMovedPermanently, statusCode)
 	assert.Empty(t, body)
 
 	serviceOptions.Hosts = []string{"other.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, targetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://other.example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusMovedPermanently, statusCode)
@@ -220,19 +220,19 @@ func TestRouter_DeploymmentsWithErrorsDoNotUpdateService(t *testing.T) {
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"example.com"}
 
-	require.NoError(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	ensureServiceIsHealthy()
 
 	t.Run("custom TLS that is not valid", func(t *testing.T) {
 		serviceOptions := ServiceOptions{TLSEnabled: true, TLSCertificatePath: "not valid", TLSPrivateKeyPath: "not valid"}
-		require.Error(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+		require.Error(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 		ensureServiceIsHealthy()
 	})
 
 	t.Run("custom error pages that are not valid", func(t *testing.T) {
 		serviceOptions := ServiceOptions{ErrorPagePath: "not valid"}
-		require.Error(t, router.DeployService("service1", []string{target}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+		require.Error(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 		ensureServiceIsHealthy()
 	})
@@ -242,13 +242,13 @@ func TestRouter_UpdatingPauseStateIndependentlyOfDeployments(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "first", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	router.PauseService("service1", time.Second, time.Millisecond*10)
 
 	statusCode, _ := sendRequest(router, httptest.NewRequest(http.MethodPost, "http://example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusGatewayTimeout, statusCode)
 
-	require.NoError(t, router.DeployService("service1", []string{target}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, _ = sendRequest(router, httptest.NewRequest(http.MethodPost, "http://example.com/", strings.NewReader("Something longer than 10")))
 	assert.Equal(t, http.StatusGatewayTimeout, statusCode)
@@ -266,7 +266,7 @@ func TestRouter_ChangingHostForService(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"dummy.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://dummy.example.com/")
 
@@ -274,7 +274,7 @@ func TestRouter_ChangingHostForService(t *testing.T) {
 	assert.Equal(t, "first", body)
 
 	serviceOptions.Hosts = []string{"dummy2.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{second}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{second}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://dummy2.example.com/")
 
@@ -293,9 +293,9 @@ func TestRouter_ReusingHost(t *testing.T) {
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"example.com"}
 
-	require.NoError(t, router.DeployService("service1", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
-	err := router.DeployService("service2", []string{second}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	err := router.DeployService("service2", []string{second}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 	require.Equal(t, ErrorHostInUse, err)
 
 	statusCode, body := sendGETRequest(router, "http://example.com/")
@@ -309,8 +309,8 @@ func TestRouter_ReusingEmptyHost(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	err := router.DeployService("service12", []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	err := router.DeployService("service12", []string{second}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 
 	require.Equal(t, ErrorHostInUse, err)
 
@@ -326,9 +326,9 @@ func TestRouter_RoutingMultipleHosts(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"s1.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.Hosts = []string{"s2.example.com"}
-	require.NoError(t, router.DeployService("service2", []string{second}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{second}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://s1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -349,11 +349,11 @@ func TestRouter_PathBasedRoutingStripPrefix(t *testing.T) {
 	serviceOptions.StripPrefix = true
 	serviceOptions.Hosts = []string{"example.com"}
 
-	require.NoError(t, router.DeployService("service1", []string{backend}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{backend}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.PathPrefixes = []string{"/app"}
-	require.NoError(t, router.DeployService("service2", []string{backend}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{backend}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.PathPrefixes = []string{"/api/internal"}
-	require.NoError(t, router.DeployService("service3", []string{backend}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service3", []string{backend}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/app/show")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -377,7 +377,7 @@ func TestRouter_PathBasedRoutingStripPrefix(t *testing.T) {
 
 	serviceOptions.StripPrefix = false
 	serviceOptions.PathPrefixes = []string{"/app"}
-	require.NoError(t, router.DeployService("service2", []string{backend}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{backend}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body = sendGETRequest(router, "http://example.com/app")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -393,9 +393,9 @@ func TestRouter_PathBasedRoutingWithHosts(t *testing.T) {
 	serviceOptions.Hosts = []string{"example.com"}
 
 	serviceOptions.PathPrefixes = []string{"/first"}
-	require.NoError(t, router.DeployService("service1", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.PathPrefixes = []string{"/second"}
-	require.NoError(t, router.DeployService("service2", []string{second}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{second}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/first")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -405,10 +405,10 @@ func TestRouter_PathBasedRoutingWithHosts(t *testing.T) {
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "second", body)
 
-	statusCode, body = sendGETRequest(router, "http://example.com/third")
+	statusCode, _ = sendGETRequest(router, "http://example.com/third")
 	assert.Equal(t, http.StatusNotFound, statusCode)
 
-	statusCode, body = sendGETRequest(router, "http://example.com/")
+	statusCode, _ = sendGETRequest(router, "http://example.com/")
 	assert.Equal(t, http.StatusNotFound, statusCode)
 }
 
@@ -420,12 +420,12 @@ func TestRouter_PathBasedRoutingWithDefaultHost(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.PathPrefixes = []string{"/first"}
-	require.NoError(t, router.DeployService("service1", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.PathPrefixes = []string{"/second"}
-	require.NoError(t, router.DeployService("service2", []string{second}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service2", []string{second}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.Hosts = []string{"third.example.com"}
 	serviceOptions.PathPrefixes = []string{"/second"}
-	require.NoError(t, router.DeployService("service3", []string{third}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service3", []string{third}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://example.com/first")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -439,7 +439,7 @@ func TestRouter_PathBasedRoutingWithDefaultHost(t *testing.T) {
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "third", body)
 
-	statusCode, body = sendGETRequest(router, "http://example.com/")
+	statusCode, _ = sendGETRequest(router, "http://example.com/")
 	assert.Equal(t, http.StatusNotFound, statusCode)
 }
 
@@ -450,8 +450,8 @@ func TestRouter_TargetWithoutHostActsAsWildcard(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"s1.example.com"}
-	require.NoError(t, router.DeployService("service1", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.DeployService("default", []string{second}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("default", []string{second}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://s1.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -474,10 +474,10 @@ func TestRouter_TargetsAllowWildcardSubdomains(t *testing.T) {
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"*.first.example.com"}
-	require.NoError(t, router.DeployService("first", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("first", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.Hosts = []string{"*.second.example.com"}
-	require.NoError(t, router.DeployService("second", []string{second}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.DeployService("fallback", []string{fallback}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("second", []string{second}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("fallback", []string{fallback}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://app.first.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -500,7 +500,7 @@ func TestRouter_WildcardDomainsCannotBeUsedWithAutomaticTLS(t *testing.T) {
 	serviceOptions.Hosts = []string{"first.example.com", "*.first.example.com"}
 	serviceOptions.TLSEnabled = true
 
-	err := router.DeployService("first", []string{first}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
+	err := router.DeployService("first", []string{first}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout)
 	require.Equal(t, ErrorAutomaticTLSDoesNotSupportWildcards, err)
 }
 
@@ -508,7 +508,7 @@ func TestRouter_ServiceFailingToBecomeHealthy(t *testing.T) {
 	router := testRouter(t)
 	_, target := testBackend(t, "", http.StatusInternalServerError)
 
-	err := router.DeployService("example", []string{target}, defaultServiceOptions, defaultTargetOptions, time.Millisecond*20, DefaultDrainTimeout)
+	err := router.DeployService("example", []string{target}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, time.Millisecond*20, DefaultDrainTimeout)
 	assert.ErrorIs(t, err, ErrorTargetFailedToBecomeHealthy)
 
 	statusCode, _ := sendGETRequest(router, "http://example.com/")
@@ -521,8 +521,8 @@ func TestRouter_EnablingRollout(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 
-	require.NoError(t, router.DeployService("service1", []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
-	require.NoError(t, router.SetRolloutTargets("service1", []string{second}, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.SetRolloutTargets("service1", []string{second}, defaultEmptyReaders, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	checkResponse := func(expected string) {
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
@@ -552,17 +552,17 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 	_, third := testBackend(t, "third", http.StatusOK)
 
 	router := NewRouter(statePath)
-	require.NoError(t, router.DeployService("default", []string{first}, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("default", []string{first}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	serviceOptions := defaultServiceOptions
 	serviceOptions.Hosts = []string{"other.example.com"}
 	serviceOptions.TLSEnabled = true
 	serviceOptions.TLSRedirect = true
-	require.NoError(t, router.DeployService("other1", []string{second}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("other1", []string{second}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 	serviceOptions.PathPrefixes = []string{"/api"}
 	serviceOptions.TLSEnabled = false
 	serviceOptions.TLSRedirect = false
-	require.NoError(t, router.DeployService("other2", []string{third}, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
+	require.NoError(t, router.DeployService("other2", []string{third}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, DefaultDeployTimeout, DefaultDrainTimeout))
 
 	statusCode, body := sendGETRequest(router, "http://something.example.com/")
 	assert.Equal(t, http.StatusOK, statusCode)

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -29,9 +29,10 @@ const (
 )
 
 const (
-	DefaultDeployTimeout = time.Second * 30
-	DefaultDrainTimeout  = time.Second * 30
-	DefaultPauseTimeout  = time.Second * 30
+	DefaultDeployTimeout         = time.Second * 30
+	DefaultDrainTimeout          = time.Second * 30
+	DefaultPauseTimeout          = time.Second * 30
+	DefaultWriterAffinityTimeout = time.Second * 3
 
 	DefaultHealthCheckPath     = "/up"
 	DefaultHealthCheckInterval = time.Second
@@ -68,16 +69,17 @@ type HealthCheckConfig struct {
 }
 
 type ServiceOptions struct {
-	Hosts              []string `json:"hosts"`
-	PathPrefixes       []string `json:"path_prefixes"`
-	TLSEnabled         bool     `json:"tls_enabled"`
-	TLSCertificatePath string   `json:"tls_certificate_path"`
-	TLSPrivateKeyPath  string   `json:"tls_private_key_path"`
-	TLSRedirect        bool     `json:"tls_redirect"`
-	ACMEDirectory      string   `json:"acme_directory"`
-	ACMECachePath      string   `json:"acme_cache_path"`
-	ErrorPagePath      string   `json:"error_page_path"`
-	StripPrefix        bool     `json:"strip_prefix"`
+	Hosts                 []string      `json:"hosts"`
+	PathPrefixes          []string      `json:"path_prefixes"`
+	TLSEnabled            bool          `json:"tls_enabled"`
+	TLSCertificatePath    string        `json:"tls_certificate_path"`
+	TLSPrivateKeyPath     string        `json:"tls_private_key_path"`
+	TLSRedirect           bool          `json:"tls_redirect"`
+	ACMEDirectory         string        `json:"acme_directory"`
+	ACMECachePath         string        `json:"acme_cache_path"`
+	ErrorPagePath         string        `json:"error_page_path"`
+	StripPrefix           bool          `json:"strip_prefix"`
+	WriterAffinityTimeout time.Duration `json:"writer_affinity_timeout"`
 }
 
 func (so *ServiceOptions) Normalize() {
@@ -115,20 +117,18 @@ type Service struct {
 	options       ServiceOptions
 	targetOptions TargetOptions
 
-	active  *LoadBalancer
-	rollout *LoadBalancer
+	active      *LoadBalancer
+	rollout     *LoadBalancer
+	serviceLock sync.RWMutex
 
 	pauseController   *PauseController
 	rolloutController *RolloutController
-	serviceLock       sync.Mutex
 
 	certManager CertManager
 	middleware  http.Handler
 }
 
 func NewService(name string, options ServiceOptions, targetOptions TargetOptions) (*Service, error) {
-	options.Normalize()
-
 	service := &Service{
 		name:            name,
 		options:         options,
@@ -139,18 +139,11 @@ func NewService(name string, options ServiceOptions, targetOptions TargetOptions
 	return service, service.initialize()
 }
 
-func (s *Service) CopyWithOptions(options ServiceOptions, targetOptions TargetOptions) (*Service, error) {
-	service, err := NewService(s.name, options, targetOptions)
-	if err != nil {
-		return nil, err
-	}
+func (s *Service) UpdateOptions(options ServiceOptions, targetOptions TargetOptions) error {
+	s.options = options
+	s.targetOptions = targetOptions
 
-	service.active = s.active
-	service.rollout = s.rollout
-	service.pauseController = s.pauseController
-	service.rolloutController = s.rolloutController
-
-	return service, service.initialize()
+	return s.initialize()
 }
 
 func (s *Service) Dispose() {
@@ -211,7 +204,9 @@ type marshalledService struct {
 	Options           ServiceOptions     `json:"options"`
 	TargetOptions     TargetOptions      `json:"target_options"`
 	ActiveTargets     []string           `json:"active_targets"`
+	ActiveReaders     []string           `json:"active_readers"`
 	RolloutTargets    []string           `json:"rollout_targets"`
+	RolloutReaders    []string           `json:"rollout_readers"`
 	PauseController   *PauseController   `json:"pause_controller"`
 	RolloutController *RolloutController `json:"rollout_controller"`
 
@@ -223,14 +218,18 @@ type marshalledService struct {
 
 func (s *Service) MarshalJSON() ([]byte, error) {
 	var rolloutTargets []string
+	var rolloutReaders []string
 	if s.rollout != nil {
-		rolloutTargets = s.rollout.Targets().Names()
+		rolloutTargets = s.rollout.WriteTargets().Names()
+		rolloutReaders = s.rollout.ReadTargets().Names()
 	}
 
 	return json.Marshal(marshalledService{
 		Name:              s.name,
-		ActiveTargets:     s.active.Targets().Names(),
+		ActiveTargets:     s.active.WriteTargets().Names(),
+		ActiveReaders:     s.active.ReadTargets().Names(),
 		RolloutTargets:    rolloutTargets,
+		RolloutReaders:    rolloutReaders,
 		Options:           s.options,
 		TargetOptions:     s.targetOptions,
 		PauseController:   s.pauseController,
@@ -265,19 +264,21 @@ func (s *Service) UnmarshalJSON(data []byte) error {
 	s.options = ms.Options
 	s.targetOptions = ms.TargetOptions
 
-	activeTargets, err := NewTargetList(ms.ActiveTargets, ms.TargetOptions)
+	activeTargets, err := NewTargetList(ms.ActiveTargets, ms.ActiveReaders, ms.TargetOptions)
 	if err != nil {
 		return err
 	}
-	s.active = NewLoadBalancer(activeTargets)
+	s.active = NewLoadBalancer(activeTargets, s.options.WriterAffinityTimeout)
 	s.active.MarkAllHealthy()
 
-	rolloutTargets, err := NewTargetList(ms.RolloutTargets, ms.TargetOptions)
+	rolloutTargets, err := NewTargetList(ms.RolloutTargets, ms.RolloutReaders, ms.TargetOptions)
 	if err != nil {
 		return err
 	}
-	s.rollout = NewLoadBalancer(rolloutTargets)
-	s.rollout.MarkAllHealthy()
+	if len(rolloutTargets) > 0 {
+		s.rollout = NewLoadBalancer(rolloutTargets, s.options.WriterAffinityTimeout)
+		s.rollout.MarkAllHealthy()
+	}
 
 	return s.initialize()
 }
@@ -428,8 +429,18 @@ func (s *Service) serviceRequestWithTarget(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	sendRequest := s.startLoadBalancerRequest(w, r)
+	if sendRequest != nil {
+		sendRequest()
+	}
+}
+
+func (s *Service) startLoadBalancerRequest(w http.ResponseWriter, r *http.Request) func() {
+	s.serviceLock.RLock()
+	defer s.serviceLock.RUnlock()
+
 	lb := s.loadBalancerForRequest(r)
-	lb.ServeHTTP(w, r)
+	return lb.StartRequest(w, r)
 }
 
 func (s *Service) shouldRedirectToHTTPS(r *http.Request) bool {

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -140,7 +140,7 @@ func TestService_MarshallingState(t *testing.T) {
 	service := testCreateService(t, defaultServiceOptions, targetOptions)
 	defer service.Dispose()
 	require.NoError(t, service.Stop(time.Second, DefaultStopMessage))
-	service.UpdateLoadBalancer(NewLoadBalancer(service.active.Targets()), TargetSlotRollout)
+	service.UpdateLoadBalancer(NewLoadBalancer(service.active.Targets(), DefaultWriterAffinityTimeout), TargetSlotRollout)
 
 	require.NoError(t, service.SetRolloutSplit(20, []string{"first"}))
 
@@ -183,7 +183,7 @@ func testCreateServiceWithHandler(t *testing.T, options ServiceOptions, targetOp
 	service, err := NewService("test", options, targetOptions)
 	require.NoError(t, err)
 
-	service.UpdateLoadBalancer(NewLoadBalancer(TargetList{target}), TargetSlotActive)
+	service.UpdateLoadBalancer(NewLoadBalancer(TargetList{target}, DefaultWriterAffinityTimeout), TargetSlotActive)
 	service.active.WaitUntilHealthy(time.Second)
 
 	return service

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -13,8 +13,7 @@ import (
 
 var (
 	defaultHealthCheckConfig = HealthCheckConfig{Path: DefaultHealthCheckPath, Interval: DefaultHealthCheckInterval, Timeout: time.Second * 5}
-	defaultEmptyHosts        = []string{}
-	defaultPaths             = []string{rootPath}
+	defaultEmptyReaders      = []string{}
 	defaultServiceOptions    = ServiceOptions{TLSRedirect: true}
 	defaultTargetOptions     = TargetOptions{HealthCheckConfig: defaultHealthCheckConfig, ResponseTimeout: DefaultTargetTimeout}
 )
@@ -25,6 +24,16 @@ func testTarget(t testing.TB, handler http.HandlerFunc) *Target {
 	_, targetURL := testBackendWithHandler(t, handler)
 
 	target, err := NewTarget(targetURL, defaultTargetOptions)
+	require.NoError(t, err)
+	return target
+}
+
+func testReadOnlyTarget(t testing.TB, handler http.HandlerFunc) *Target {
+	t.Helper()
+
+	_, targetURL := testBackendWithHandler(t, handler)
+
+	target, err := NewReadOnlyTarget(targetURL, defaultTargetOptions)
 	require.NoError(t, err)
 	return target
 }


### PR DESCRIPTION
In addition to specifying one or more `--target` servers to deploy, you can now also specify one or more `--read-target`. When any read targets are present, traffic will be routed such that read requests go to read targets, and write requests go to write targets.

A read request is defined as a `GET` or `HEAD`, and excludes WebSocket traffic. Everything else is considered to be a write request.

Read requests that immediately follow a write on the same session will also be treated as writes. In configurations where readers are replicas of writers, this helps avoid problems where replication lag leads to a client failing to read an item it just wrote. This "writer affinity" is controlled by a cookie, and by default the effect lasts for 3 seconds. It can be adjusted via `--writer-affinity-timeout`, or disabled entirely by setting the timeout to zero.

Aside from this writer affinity case, writers will not receive any read requests unless they are also explicitly listed as a `--read-target`