### PR TITLE
Skip writer affinity via header

### DIFF
--- a/internal/server/load_balancer.go
+++ b/internal/server/load_balancer.go
@@ -172,7 +172,7 @@ func (lb *LoadBalancer) StartRequest(w http.ResponseWriter, r *http.Request) fun
 		return nil
 	}
 
-	if lb.hasReaders && !readRequest {
+	if lb.hasReaders && !readRequest && !lb.skipsWriterAffinity(r) {
 		lb.setWriteCookie(w)
 	}
 
@@ -222,6 +222,10 @@ func (lb *LoadBalancer) nextTarget(reader bool) *Target {
 func (lb *LoadBalancer) isReadRequest(req *http.Request) bool {
 	return (req.Method == http.MethodGet || req.Method == http.MethodHead) &&
 		(lb.readTargetsAcceptWebsockets || !lb.isWebSocketRequest(req))
+}
+
+func (lb *LoadBalancer) skipsWriterAffinity(req *http.Request) bool {
+	return req.Header.Get("X-Writer-Affinity") == "false"
 }
 
 func (lb *LoadBalancer) isWebSocketRequest(req *http.Request) bool {

--- a/internal/server/load_balancer_test.go
+++ b/internal/server/load_balancer_test.go
@@ -189,6 +189,16 @@ func TestLoadBalancer_Readers(t *testing.T) {
 		w := checkResponse(lb, httptest.NewRequest("PUT", "/something", nil), isWriter)
 		assert.Empty(t, w.Result().Cookies())
 	})
+
+	t.Run("writer affinity not active when `X-Writer-Affinity` header is `false`", func(t *testing.T) {
+		lb := createDefaultLoadBalancer(true)
+
+		req := httptest.NewRequest("PUT", "/something", nil)
+		req.Header.Set("X-Writer-Affinity", "false")
+
+		w := checkResponse(lb, req, isWriter)
+		assert.Empty(t, w.Result().Cookies())
+	})
 }
 
 // Helpers


### PR DESCRIPTION
In cases where a write should be excluded from triggering writer affinity, a client can set the header `X-Writer-Affinity=false`. This can be useful for certain requests, like beacons, that result in unnecessary pinning to the writer because the result of those requests isn't visible on the page (meaning that the risk of reading stale data after writing doesn't apply).