### PR TITLE
ci: get go version from go.mod for ci/cd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.x'
+        go-version-file: go.mod
 
     - name: Install dependencies
       run: go mod download


### PR DESCRIPTION
let's just use the same go version numbers that specified in go.mod for ci.