### PR TITLE
Custom health check port

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,17 @@ request to `/up`, once per second. A `200` response is considered healthy.
 
 If you need to customize the health checks for your application, there are a
 few `deploy` flags you can use. See the help for `--health-check-path`,
-`--health-check-timeout`, and `--health-check-interval`.
+`--health-check-port`, `--health-check-timeout`, and `--health-check-interval`.
 
 For example, to change the health check path to something other than `/up`, you
 could:
 
     kamal-proxy deploy service1 --target web-1:3000 --health-check-path web/index.html
+
+To configure health checks to run on a different port than your main service
+(useful when your app exposes health endpoints on a dedicated port), you could:
+
+    kamal-proxy deploy service1 --target web-1:3000 --health-check-port 8080
 
 ### Host-based routing
 

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -44,6 +44,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Interval, "health-check-interval", server.DefaultHealthCheckInterval, "Interval between health checks")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Timeout, "health-check-timeout", server.DefaultHealthCheckTimeout, "Time each health check must complete in")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Path, "health-check-path", server.DefaultHealthCheckPath, "Path to check for health")
+	deployCommand.cmd.Flags().IntVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Port, "health-check-port", server.DefaultHealthCheckPort, "Port to check for health")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.ServiceOptions.WriterAffinityTimeout, "writer-affinity-timeout", server.DefaultWriterAffinityTimeout, "Time after a write before read requests will be routed to readers")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.ReadTargetsAcceptWebsockets, "read-target-websockets", false, "Route WebSocket traffic to read targets, when available")
 

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -35,6 +35,7 @@ const (
 	DefaultWriterAffinityTimeout = time.Second * 3
 
 	DefaultHealthCheckPath     = "/up"
+	DefaultHealthCheckPort     = 0
 	DefaultHealthCheckInterval = time.Second
 	DefaultHealthCheckTimeout  = time.Second * 5
 
@@ -64,6 +65,7 @@ const (
 
 type HealthCheckConfig struct {
 	Path     string        `json:"path"`
+	Port     int           `json:"port"`
 	Interval time.Duration `json:"interval"`
 	Timeout  time.Duration `json:"timeout"`
 }

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	defaultHealthCheckConfig = HealthCheckConfig{Path: DefaultHealthCheckPath, Interval: DefaultHealthCheckInterval, Timeout: time.Second * 5}
+	defaultHealthCheckConfig = HealthCheckConfig{Path: DefaultHealthCheckPath, Port: DefaultHealthCheckPort, Interval: DefaultHealthCheckInterval, Timeout: time.Second * 5}
 	defaultEmptyReaders      = []string{}
 	defaultServiceOptions    = ServiceOptions{TLSRedirect: true}
 	defaultTargetOptions     = TargetOptions{HealthCheckConfig: defaultHealthCheckConfig, ResponseTimeout: DefaultTargetTimeout}


### PR DESCRIPTION
Hi Basecamp team,

I'm currently facing similar issue with what have been discussed in these posts:
- https://github.com/basecamp/kamal-proxy/discussions/132
- https://github.com/basecamp/kamal/issues/1234

Essentially, I'm trying to deploy an open source project ([vector](https://github.com/vectordotdev/vector)) using Kamal, but vector only supports health check that [lives in different port](https://github.com/vectordotdev/vector/issues/5710). 

Since our team already invested in Kamal, it would be a bummer to move our setup to different tools.

Would it be acceptable to allow port customization as proposed in this PR? Do let me know if you need me to approach things differently. I will also raise a PR to kamal if this is approved.

Thank You,