### PR TITLE
Add canonical host redirect feature

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -38,6 +38,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "Configure custom TLS certificate path (PEM format)")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "Configure custom TLS private key path (PEM format)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSRedirect, "tls-redirect", true, "Redirect HTTP traffic to HTTPS")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.CanonicalHost, "canonical-host", "", "Redirect all requests to this host (e.g., force root or www)")
 
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DeployTimeout, "deploy-timeout", server.DefaultDeployTimeout, "Maximum time to wait for the new target to become healthy")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.DrainTimeout, "drain-timeout", server.DefaultDrainTimeout, "Maximum time to allow existing connections to drain before removing old target")


### PR DESCRIPTION
### Summary
Adds **host canonicalization** to redirect all requests to a single canonical host, e.g., force root (`domain.com`) or `www` (`www.domain.com`).  
Supports both directions:
- `www.domain.com → domain.com`
- `domain.com → www.domain.com`

Redirects happen in **one hop** even with TLS (e.g., `http://www` → `https://root`).

### Changes
- Added `CanonicalHost` to `ServiceOptions`
- Centralized redirect logic to handle both scheme and host together
- Added `--canonical-host` flag to `deploy` command
- Added full test coverage for canonical host redirects (including TLS cases)

### Motivation
Kamal currently has no built-in way to handle `www` ↔ root redirects, forcing users to rely on Cloudflare or custom reverse proxy rules.  
This is a **basic feature in most reverse proxies**, and this PR makes it available natively in Kamal.

### Compatibility
Backwards compatible, only active when explicitly configured.
