### PR TITLE
go: prepare the pause controller for Go1.25.0 and jsonv2

### DIFF
--- a/internal/server/pause_controller.go
+++ b/internal/server/pause_controller.go
@@ -49,8 +49,8 @@ func NewPauseController() *PauseController {
 }
 
 func (p *PauseController) UnmarshalJSON(data []byte) error {
-	type alias *PauseController // Avoid infinite recursion when we call Unmarshal
-	err := json.Unmarshal(data, alias(p))
+	type alias PauseController // Avoid infinite recursion when we call Unmarshal
+	err := json.Unmarshal(data, (*alias)(p))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pr adds support for jsonv2 from Go1.25.0.
The jsonv2 package has different behavior in resolving Marshaler/Unmarshaler interfaces than in the v1.
The pause controller has to be updated.

To check it with Go1.25.0 toolchain you can try following command:
```bash
GOEXPERIMENT=jsonv2,greenteagc go test ./...       
```