### PR TITLE
Serve metrics optionally via HTTPS

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -28,6 +28,7 @@ func newRunCommand() *runCommand {
 	runCommand.cmd.Flags().IntVar(&globalConfig.HttpPort, "http-port", getEnvInt("HTTP_PORT", server.DefaultHttpPort), "Port to serve HTTP traffic on")
 	runCommand.cmd.Flags().IntVar(&globalConfig.HttpsPort, "https-port", getEnvInt("HTTPS_PORT", server.DefaultHttpsPort), "Port to serve HTTPS traffic on")
 	runCommand.cmd.Flags().IntVar(&globalConfig.MetricsPort, "metrics-port", getEnvInt("METRICS_PORT", 0), "Publish metrics on the specified port (default zero to disable)")
+	runCommand.cmd.Flags().BoolVar(&globalConfig.MetricsHttps, "metrics-https", getEnvBool("METRICS_HTTPS", false), "Enable HTTPS for the metrics port (default false for HTTP)")
 
 	return runCommand
 }

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -13,11 +13,11 @@ const (
 )
 
 type Config struct {
-	Bind        string
-	HttpPort    int
-	HttpsPort   int
-	MetricsPort int
-
+	Bind               string
+	HttpPort           int
+	HttpsPort          int
+	MetricsPort        int
+	MetricsHttps       bool
 	AlternateConfigDir string
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -173,10 +173,17 @@ func (s *Server) startMetricsServer() error {
 		Addr:    addr,
 		Handler: handler,
 	}
+	if s.config.MetricsHttps {
+		s.metricsServer.TLSConfig = &tls.Config{
+			MinVersion:     tls.VersionTLS13,
+			GetCertificate: s.router.GetCertificate,
+		}
+		go s.metricsServer.ServeTLS(s.metricsListener, "", "")
+	} else {
+		go s.metricsServer.Serve(s.metricsListener)
+	}
 
-	go s.metricsServer.Serve(s.metricsListener)
-
-	slog.Info("Metrics enabled", "address", addr)
+	slog.Info("Metrics enabled", "port", s.config.MetricsPort, "https", s.config.MetricsHttps)
 
 	return nil
 }


### PR DESCRIPTION
Adds a config parameter `--metrics-https` (or env `METRICS_HTTPS`) that serves the metrics via `HTTPS` instead of `HTTP`.
It is reusing the TLS server certificates of the existing configured services of this proxy.

The metrics enablement parameter was named just `--metrics-port` instead of `--metrics-http-port`. 
Thus now this is just an additional `bool` config flag to toggle HTTPS. To match the general port config parameter names, it could have also be named `--metrics-https-port`. On the other hand I see no benefit of actually allowing to run the metrics on two ports for HTTPS and HTTP.

To reduce the need for more config parameters for the metrics server certificate and key files, it just reuses the already configured matching service certificates.

Started a discussion about this here: https://github.com/basecamp/kamal-proxy/discussions/101#discussioncomment-14174612