### PR TITLE
fix: respect Transfer-Encoding chunked for streaming responses

### DIFF
--- a/internal/server/response_buffer_middleware.go
+++ b/internal/server/response_buffer_middleware.go
@@ -83,8 +83,18 @@ func (w *bufferedResponseWriter) WriteHeader(statusCode int) {
 }
 
 func (w *bufferedResponseWriter) ShouldSwitchToUnbuffered() bool {
+	// Check for explicit streaming content types
 	contentType, _, _ := strings.Cut(w.Header().Get("Content-Type"), ";")
-	return contentType == "text/event-stream"
+	if contentType == "text/event-stream" {
+		return true
+	}
+
+	// Check for chunked transfer encoding - RFC 7230 indicates this is for streaming
+	if w.Header().Get("Transfer-Encoding") == "chunked" {
+		return true
+	}
+
+	return false
 }
 
 func (w *bufferedResponseWriter) SwitchToUnbuffered() {

--- a/internal/server/response_buffer_middleware_test.go
+++ b/internal/server/response_buffer_middleware_test.go
@@ -56,28 +56,184 @@ func TestResponseBufferMiddleware_BufferedResponsesIgnoreFlushes(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "http://example.com")
 }
 
-func TestResponseBufferMiddleware_SSEResponsesBypassBufferAndAreFlushable(t *testing.T) {
-	checkContentType := func(contentType string, shouldFlush bool) {
-		req := httptest.NewRequest(http.MethodGet, "http://app.example.com/somepath", nil)
-		rec := httptest.NewRecorder()
-
-		middleware := WithResponseBufferMiddleware(1024, 1024, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", contentType)
-			w.WriteHeader(http.StatusOK)
-
-			w.Write([]byte("data: hello\n\n"))
-			w.(http.Flusher).Flush()
-
-			assert.Equal(t, shouldFlush, rec.Flushed)
-		}))
-
-		middleware.ServeHTTP(rec, req)
-
-		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
-		assert.Contains(t, rec.Body.String(), "data: hello")
+func TestResponseBufferMiddleware_StreamingResponsesBypassBuffer(t *testing.T) {
+	testCases := []struct {
+		name         string
+		setupHeaders func(http.Header)
+		shouldBypass bool
+		description  string
+	}{
+		{
+			name: "text/event-stream bypasses buffer",
+			setupHeaders: func(h http.Header) {
+				h.Set("Content-Type", "text/event-stream")
+			},
+			shouldBypass: true,
+			description:  "Server-Sent Events should bypass buffering",
+		},
+		{
+			name: "text/event-stream with charset bypasses buffer",
+			setupHeaders: func(h http.Header) {
+				h.Set("Content-Type", "text/event-stream; charset=utf-8")
+			},
+			shouldBypass: true,
+			description:  "Server-Sent Events with charset should bypass buffering",
+		},
+		{
+			name: "chunked transfer encoding bypasses buffer",
+			setupHeaders: func(h http.Header) {
+				h.Set("Transfer-Encoding", "chunked")
+				h.Set("Content-Type", "text/plain")
+			},
+			shouldBypass: true,
+			description:  "Chunked encoding indicates streaming and should bypass buffering",
+		},
+		{
+			name: "chunked with text/event-stream bypasses buffer",
+			setupHeaders: func(h http.Header) {
+				h.Set("Transfer-Encoding", "chunked")
+				h.Set("Content-Type", "text/event-stream")
+			},
+			shouldBypass: true,
+			description:  "Both chunked and SSE should bypass buffering",
+		},
+		{
+			name: "MessageBus long-polling with chunked bypasses buffer",
+			setupHeaders: func(h http.Header) {
+				h.Set("Transfer-Encoding", "chunked")
+				h.Set("Content-Type", "text/plain")
+			},
+			shouldBypass: true,
+			description:  "MessageBus-style long polling with chunked encoding should bypass buffering",
+		},
+		{
+			name: "streaming JSON with chunked bypasses buffer",
+			setupHeaders: func(h http.Header) {
+				h.Set("Transfer-Encoding", "chunked")
+				h.Set("Content-Type", "application/json")
+			},
+			shouldBypass: true,
+			description:  "Streaming JSON responses with chunked encoding should bypass buffering",
+		},
+		{
+			name: "regular response is buffered",
+			setupHeaders: func(h http.Header) {
+				h.Set("Content-Type", "text/plain")
+				h.Set("Content-Length", "100")
+			},
+			shouldBypass: false,
+			description:  "Regular responses with Content-Length should be buffered",
+		},
+		{
+			name: "regular JSON response is buffered",
+			setupHeaders: func(h http.Header) {
+				h.Set("Content-Type", "application/json")
+				h.Set("Content-Length", "50")
+			},
+			shouldBypass: false,
+			description:  "Regular JSON responses with Content-Length should be buffered",
+		},
 	}
 
-	checkContentType("text/event-stream", true)
-	checkContentType("text/event-stream; charset=utf-8", true)
-	checkContentType("text/plain", false)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://app.example.com/somepath", nil)
+			rec := httptest.NewRecorder()
+
+			middleware := WithResponseBufferMiddleware(1024, 1024, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Setup headers as specified in test case
+				tc.setupHeaders(w.Header())
+				w.WriteHeader(http.StatusOK)
+
+				// Write some data
+				w.Write([]byte("test data"))
+
+				// Try to flush - this should only work if bypassing buffer
+				w.(http.Flusher).Flush()
+
+				// Check if the response was flushed (indicating bypass)
+				assert.Equal(t, tc.shouldBypass, rec.Flushed, tc.description)
+			}))
+
+			middleware.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+			assert.Contains(t, rec.Body.String(), "test data")
+		})
+	}
+}
+
+func TestBufferedResponseWriter_ShouldSwitchToUnbuffered(t *testing.T) {
+	testCases := []struct {
+		name         string
+		setupHeaders func(http.Header)
+		expected     bool
+		description  string
+	}{
+		{
+			name: "text/event-stream should switch",
+			setupHeaders: func(h http.Header) {
+				h.Set("Content-Type", "text/event-stream")
+			},
+			expected:    true,
+			description: "Server-Sent Events should switch to unbuffered",
+		},
+		{
+			name: "text/event-stream with charset should switch",
+			setupHeaders: func(h http.Header) {
+				h.Set("Content-Type", "text/event-stream; charset=utf-8")
+			},
+			expected:    true,
+			description: "Server-Sent Events with charset should switch to unbuffered",
+		},
+		{
+			name: "chunked transfer encoding should switch",
+			setupHeaders: func(h http.Header) {
+				h.Set("Transfer-Encoding", "chunked")
+			},
+			expected:    true,
+			description: "Chunked transfer encoding should switch to unbuffered",
+		},
+		{
+			name: "chunked with any content type should switch",
+			setupHeaders: func(h http.Header) {
+				h.Set("Transfer-Encoding", "chunked")
+				h.Set("Content-Type", "application/json")
+			},
+			expected:    true,
+			description: "Chunked encoding should switch regardless of content type",
+		},
+		{
+			name: "regular content should not switch",
+			setupHeaders: func(h http.Header) {
+				h.Set("Content-Type", "text/plain")
+			},
+			expected:    false,
+			description: "Regular content without streaming indicators should not switch",
+		},
+		{
+			name: "empty headers should not switch",
+			setupHeaders: func(h http.Header) {
+				// No headers set
+			},
+			expected:    false,
+			description: "Empty headers should not switch to unbuffered",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writer := &bufferedResponseWriter{
+				ResponseWriter: rec,
+				statusCode:     http.StatusOK,
+			}
+
+			// Setup headers as specified in test case
+			tc.setupHeaders(writer.Header())
+
+			result := writer.ShouldSwitchToUnbuffered()
+			assert.Equal(t, tc.expected, result, tc.description)
+		})
+	}
 }


### PR DESCRIPTION
## Problem
The current response buffer middleware only bypasses buffering for `text/event-stream`, 
but many legitimate streaming use cases use `Transfer-Encoding: chunked` with other 
content types:

- Long-polling applications (like MessageBus) https://github.com/discourse/message_bus 
- Streaming JSON APIs  
- Real-time log streaming
- Progressive downloads

## Solution
When a server explicitly sets `Transfer-Encoding: chunked`, it's indicating the 
response is being generated dynamically. Buffering such responses can:

1. **Break streaming semantics** - Defeats the purpose of chunked encoding
2. **Increase latency** - Delays delivery of streaming data
3. **Cause application failures** - As experienced with MessageBus deployment

## Standards Alignment
While RFC 7230 doesn't explicitly forbid proxy buffering of chunked responses, 
it does indicate that chunked encoding is specifically for "dynamically generated 
payload" and "long polling" scenarios. This change ensures the proxy respects 
the server's explicit signaling about response delivery semantics.

### Discussion opened 

https://github.com/basecamp/kamal-proxy/discussions/165 