### PR TITLE
Modernize test code for Go 1.25

### DIFF
--- a/internal/server/load_balancer_test.go
+++ b/internal/server/load_balancer_test.go
@@ -28,7 +28,7 @@ func TestLoadBalancer_Targets(t *testing.T) {
 	require.NoError(t, err)
 
 	lb := NewLoadBalancer(tl, DefaultWriterAffinityTimeout, false)
-	defer lb.Dispose()
+	t.Cleanup(lb.Dispose)
 
 	assert.Equal(t, []string{"one", "two", "three"}, lb.Targets().Names())
 }

--- a/internal/server/pause_controller_test.go
+++ b/internal/server/pause_controller_test.go
@@ -25,11 +25,9 @@ func TestPauseController_WaitBlocksWhenPaused(t *testing.T) {
 	require.NoError(t, p.Pause(time.Second))
 	assert.Equal(t, PauseStatePaused, p.GetState())
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		require.NoError(t, p.Resume())
-		wg.Done()
-	}()
+	})
 
 	action, message := p.Wait()
 	assert.Equal(t, PauseWaitActionProceed, action)
@@ -66,11 +64,9 @@ func TestPauseController_StoppingPausedRequestsFailsThemImmediately(t *testing.T
 	require.NoError(t, p.Pause(time.Second))
 	assert.Equal(t, PauseStatePaused, p.GetState())
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		require.NoError(t, p.Stop("Back in 15 mins!"))
-		wg.Done()
-	}()
+	})
 
 	action, message := p.Wait()
 	assert.Equal(t, PauseWaitActionStopped, action)

--- a/internal/server/proxy_buffer_pool.go
+++ b/internal/server/proxy_buffer_pool.go
@@ -5,7 +5,7 @@ import "sync"
 func NewBufferPool(bufferSize int64) *BufferPool {
 	return &BufferPool{
 		pool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, bufferSize)
 				return &buf
 			},

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -138,7 +138,7 @@ func TestService_MarshallingState(t *testing.T) {
 	}
 
 	service := testCreateService(t, defaultServiceOptions, targetOptions)
-	defer service.Dispose()
+	t.Cleanup(service.Dispose)
 	require.NoError(t, service.Stop(time.Second, DefaultStopMessage))
 	service.UpdateLoadBalancer(NewLoadBalancer(service.active.Targets(), DefaultWriterAffinityTimeout, false), TargetSlotRollout)
 
@@ -151,7 +151,7 @@ func TestService_MarshallingState(t *testing.T) {
 	var service2 Service
 	err = json.NewDecoder(&buf).Decode(&service2)
 	require.NoError(t, err)
-	defer service2.Dispose()
+	t.Cleanup(service2.Dispose)
 
 	assert.Equal(t, service.name, service2.name)
 	assert.Equal(t, service.active.Targets().Names(), service2.active.Targets().Names())
@@ -207,7 +207,7 @@ func TestService_UnmarshallingStateFromLegacyFormat(t *testing.T) {
 	var service Service
 	err := json.NewDecoder(strings.NewReader(state)).Decode(&service)
 	require.NoError(t, err)
-	defer service.Dispose()
+	t.Cleanup(service.Dispose)
 
 	assert.Equal(t, "my-app", service.name)
 	assert.Equal(t, []string{"localhost:3000"}, service.active.Targets().Names())

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -7,13 +7,8 @@ import (
 func PerformConcurrently(fns ...func()) {
 	var wg sync.WaitGroup
 
-	wg.Add(len(fns))
-
 	for _, fn := range fns {
-		go func() {
-			defer wg.Done()
-			fn()
-		}()
+		wg.Go(fn)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
- Use sync.WaitGroup.Go() to simplify concurrent execution patterns
- Replace defer with t.Cleanup() for better test cleanup semantics
- Add tb.Helper() to test helper functions for accurate failure reporting
- Use t.Context() for better test lifecycle management
- Replace interface{} with any for modern Go style
