### PR TITLE
Serve a default cert if SNI server name missing

### DIFF
--- a/internal/server/service_map_test.go
+++ b/internal/server/service_map_test.go
@@ -71,6 +71,16 @@ func TestServiceMap_CheckAvailability(t *testing.T) {
 	assert.Equal(t, "3", sm.CheckAvailability("4", normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}, PathPrefixes: []string{"/api"}})).name)
 }
 
+func TestServiceMap_DefaultTLSHostname(t *testing.T) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}})})
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"app.example.com"}})})
+	assert.Empty(t, sm.DefaultTLSHostname())
+
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}, TLSEnabled: true})})
+	assert.Equal(t, "example.com", sm.DefaultTLSHostname())
+}
+
 func TestServiceMap_SyncingTLSSettingsFromRootPath(t *testing.T) {
 	sm := NewServiceMap()
 	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"1.example.com"}, TLSEnabled: true, TLSRedirect: false})})


### PR DESCRIPTION
Generally we expect all TLS traffic to use SNI, and that allows us to match up the connection to the deployment that holds its cert.

However, some scenarios might require making a TLS request without SNI. (One specific case we've seen for this is a healthcheck from an F5 load balancer.) So to have a best-effort attempt at servicing these requests, we'll default to using the first available TLS-enabled hostname that we have if there is no SNI to go off.

Fixes #171 