### PR TITLE
Allow HEAD healthchecks to succeed in maintenance

### DIFF
--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -76,7 +76,7 @@ type TargetOptions struct {
 }
 
 func (to *TargetOptions) IsHealthCheckRequest(r *http.Request) bool {
-	return r.Method == http.MethodGet && r.URL.Path == to.HealthCheckConfig.Path
+	return (r.Method == http.MethodGet || r.Method == http.MethodHead) && r.URL.Path == to.HealthCheckConfig.Path
 }
 
 func (to *TargetOptions) canonicalizeLogHeaders() {

--- a/internal/server/target_test.go
+++ b/internal/server/target_test.go
@@ -279,7 +279,9 @@ func TestTarget_IsHealthCheckRequest(t *testing.T) {
 	target := testTarget(t, func(w http.ResponseWriter, r *http.Request) {})
 
 	assert.True(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up", nil)))
+	assert.True(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodHead, "/up", nil)))
 	assert.True(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up?one=two", nil)))
+	assert.True(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodHead, "/up?one=two", nil)))
 
 	assert.False(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/up/other", nil)))
 	assert.False(t, target.options.IsHealthCheckRequest(httptest.NewRequest(http.MethodGet, "/health", nil)))


### PR DESCRIPTION
When an service has been stopped for maintenance, we return 503 for most requests. However, we special-case the healthcheck endpoint to return 200 so that downstream load balancers won't consider us unhealthy and hide the maintenance page.

Previously we were only doing this for `GET` requests, but since some healthchecks use `HEAD` we'll now include that as well.

/cc @flavorjones @fern4lvarez 