### PR TITLE
Support setting the Host header on health checks

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -46,6 +46,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Timeout, "health-check-timeout", server.DefaultHealthCheckTimeout, "Time each health check must complete in")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Path, "health-check-path", server.DefaultHealthCheckPath, "Path to check for health")
 	deployCommand.cmd.Flags().IntVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Port, "health-check-port", server.DefaultHealthCheckPort, "Port to check for health (default matches target port)")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.TargetOptions.HealthCheckConfig.Host, "health-check-host", "", "Host header to send with health check requests")
 	deployCommand.cmd.Flags().DurationVar(&deployCommand.args.ServiceOptions.WriterAffinityTimeout, "writer-affinity-timeout", server.DefaultWriterAffinityTimeout, "Time after a write before read requests will be routed to readers")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.ReadTargetsAcceptWebsockets, "read-target-websockets", false, "Route WebSocket traffic to read targets, when available")
 

--- a/internal/server/health_check.go
+++ b/internal/server/health_check.go
@@ -29,12 +29,13 @@ type HealthCheck struct {
 	endpoint *url.URL
 	interval time.Duration
 	timeout  time.Duration
+	host     string
 
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
-func NewHealthCheck(consumer HealthCheckConsumer, endpoint *url.URL, interval time.Duration, timeout time.Duration) *HealthCheck {
+func NewHealthCheck(consumer HealthCheckConsumer, endpoint *url.URL, interval time.Duration, timeout time.Duration, host string) *HealthCheck {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	hc := &HealthCheck{
@@ -42,6 +43,7 @@ func NewHealthCheck(consumer HealthCheckConsumer, endpoint *url.URL, interval ti
 		endpoint: endpoint,
 		interval: interval,
 		timeout:  timeout,
+		host:     host,
 
 		ctx:    ctx,
 		cancel: cancel,
@@ -84,6 +86,10 @@ func (hc *HealthCheck) check() {
 	}
 
 	req.Header.Set("User-Agent", healthCheckUserAgent)
+
+	if hc.host != "" {
+		req.Host = hc.host
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -68,6 +68,7 @@ type HealthCheckConfig struct {
 	Port     int           `json:"port"`
 	Interval time.Duration `json:"interval"`
 	Timeout  time.Duration `json:"timeout"`
+	Host     string        `json:"host"`
 }
 
 type ServiceOptions struct {

--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -224,6 +224,7 @@ func (t *Target) BeginHealthChecks(stateConsumer TargetStateConsumer) {
 			healthCheckURL,
 			t.options.HealthCheckConfig.Interval,
 			t.options.HealthCheckConfig.Timeout,
+			t.options.HealthCheckConfig.Host,
 		)
 	})
 }


### PR DESCRIPTION
Many web applications validate the `Host` header for security (think Django's `ALLOWED_HOSTS`, Rails, etc.). When kamal-proxy performs health checks using internal IPs like `http://10.0.1.5:3000/up`, the application sees `Host: 10.0.1.5:3000` and rejects it. This causes the proxy to incorrectly mark healthy targets as unhealthy.

For example, if your app only allows `example.com` in its host validation, health checks using the internal IP will fail even though the application is working fine.

## Solution

This PR adds a `--health-check-host` flag that lets you set a custom `Host` header for health check requests.

```bash
kamal-proxy deploy myapp \
  --target http://10.0.1.5:3000 \
  --health-check-path /up \
  --health-check-host example.com
```

Now health checks will include `Host: example.com` and pass validation.

The flag is optional and backward compatible. When not specified, the default behavior is unchanged. It works with both GET and HEAD health checks, and is available via both CLI and JSON API.

## Testing

Added unit tests to verify the custom Host header is sent correctly, health checks pass/fail based on header validation, and default behavior works when the flag isn't used.
