### PR TITLE
Add `--scope-cookie-paths`

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -60,8 +60,8 @@ func newDeployCommand() *deployCommand {
 
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.TargetOptions.LogRequestHeaders, "log-request-header", nil, "Additional request header to log (may be specified multiple times)")
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.TargetOptions.LogResponseHeaders, "log-response-header", nil, "Additional response header to log (may be specified multiple times)")
-
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.TargetOptions.ForwardHeaders, "forward-headers", false, "Forward X-Forwarded headers to target (default false if TLS enabled; otherwise true)")
+	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.TargetOptions.ScopeCookiePaths, "scope-cookie-paths", false, "Scope cookie paths to match path prefix")
 
 	deployCommand.cmd.MarkFlagRequired("target")
 	deployCommand.cmd.MarkFlagsRequiredTogether("tls-certificate-path", "tls-private-key-path")

--- a/internal/server/cookie_scope.go
+++ b/internal/server/cookie_scope.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// CookieScope handles scoping Set-Cookie paths to a path prefix.
+type CookieScope struct {
+	pathPrefix string
+	host       string
+}
+
+func NewCookieScope(pathPrefix string, host string) *CookieScope {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+
+	return &CookieScope{
+		pathPrefix: pathPrefix,
+		host:       host,
+	}
+}
+
+func (cs *CookieScope) ApplyToHeader(header http.Header) {
+	cookies := header["Set-Cookie"]
+	for i, v := range cookies {
+		cookie, err := http.ParseSetCookie(v)
+		if err != nil || !cs.domainMatches(cookie.Domain) {
+			continue
+		}
+
+		cookie.Path, err = url.JoinPath(cs.pathPrefix, strings.Trim(cookie.Path, "/"))
+		if err == nil {
+			cookies[i] = cookie.String()
+		}
+	}
+}
+
+func (cs *CookieScope) domainMatches(cookieDomain string) bool {
+	return cookieDomain == "" || cookieDomain == cs.host
+}

--- a/internal/server/cookie_scope_test.go
+++ b/internal/server/cookie_scope_test.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCookieScope_ApplyToHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		pathPrefix     string
+		host           string
+		inputCookies   []string
+		expectedPaths  []string
+	}{
+		{
+			name:           "scopes cookie with root path",
+			pathPrefix:     "/api",
+			host:           "example.com",
+			inputCookies:   []string{"session=abc; Path=/"},
+			expectedPaths:  []string{"/api"},
+		},
+		{
+			name:           "scopes cookie with subpath",
+			pathPrefix:     "/api",
+			host:           "example.com",
+			inputCookies:   []string{"session=abc; Path=/admin"},
+			expectedPaths:  []string{"/api/admin"},
+		},
+		{
+			name:           "scopes cookie without path",
+			pathPrefix:     "/api",
+			host:           "example.com",
+			inputCookies:   []string{"session=abc"},
+			expectedPaths:  []string{"/api"},
+		},
+		{
+			name:           "scopes first-party cookie with matching domain",
+			pathPrefix:     "/api",
+			host:           "example.com",
+			inputCookies:   []string{"session=abc; Path=/; Domain=example.com"},
+			expectedPaths:  []string{"/api"},
+		},
+		{
+			name:           "does not scope third-party cookie",
+			pathPrefix:     "/api",
+			host:           "example.com",
+			inputCookies:   []string{"tracking=xyz; Path=/; Domain=other.com"},
+			expectedPaths:  []string{"/"},
+		},
+		{
+			name:           "handles multiple cookies",
+			pathPrefix:     "/app",
+			host:           "example.com",
+			inputCookies:   []string{"a=1; Path=/", "b=2; Path=/foo", "c=3; Path=/; Domain=third.com"},
+			expectedPaths:  []string{"/app", "/app/foo", "/"},
+		},
+		{
+			name:           "handles host with port",
+			pathPrefix:     "/api",
+			host:           "example.com:8080",
+			inputCookies:   []string{"session=abc; Path=/; Domain=example.com"},
+			expectedPaths:  []string{"/api"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := NewCookieScope(tt.pathPrefix, tt.host)
+			header := http.Header{}
+			header["Set-Cookie"] = tt.inputCookies
+
+			cs.ApplyToHeader(header)
+
+			cookies := header["Set-Cookie"]
+			assert.Len(t, cookies, len(tt.expectedPaths))
+
+			for i, cookieStr := range cookies {
+				cookie, err := http.ParseSetCookie(cookieStr)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedPaths[i], cookie.Path, "cookie %d path mismatch", i)
+			}
+		})
+	}
+}
+
+func TestCookieScope_DomainMatching(t *testing.T) {
+	tests := []struct {
+		name         string
+		host         string
+		cookieDomain string
+		shouldScope  bool
+	}{
+		{
+			name:         "empty domain matches",
+			host:         "example.com",
+			cookieDomain: "",
+			shouldScope:  true,
+		},
+		{
+			name:         "exact domain match",
+			host:         "example.com",
+			cookieDomain: "example.com",
+			shouldScope:  true,
+		},
+		{
+			name:         "different domain does not match",
+			host:         "example.com",
+			cookieDomain: "other.com",
+			shouldScope:  false,
+		},
+		{
+			name:         "subdomain does not match parent",
+			host:         "example.com",
+			cookieDomain: "sub.example.com",
+			shouldScope:  false,
+		},
+		{
+			name:         "parent does not match subdomain host",
+			host:         "sub.example.com",
+			cookieDomain: "example.com",
+			shouldScope:  false,
+		},
+		{
+			name:         "host with port matches domain",
+			host:         "example.com:8080",
+			cookieDomain: "example.com",
+			shouldScope:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := NewCookieScope("/api", tt.host)
+
+			header := http.Header{}
+			if tt.cookieDomain == "" {
+				header["Set-Cookie"] = []string{"test=value; Path=/original"}
+			} else {
+				header["Set-Cookie"] = []string{"test=value; Path=/original; Domain=" + tt.cookieDomain}
+			}
+
+			cs.ApplyToHeader(header)
+
+			cookie, err := http.ParseSetCookie(header["Set-Cookie"][0])
+			assert.NoError(t, err)
+
+			if tt.shouldScope {
+				assert.Equal(t, "/api/original", cookie.Path)
+			} else {
+				assert.Equal(t, "/original", cookie.Path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a mechanism to automatically scope cookie paths to match `--path-prefix`.

When `--scope-cookie-paths` is `true` and a request matches a `--path-prefix`, any cookies set by the response will automatically have their paths scoped to the matched prefix.

For example, given a service that is deployed with:

    ... --path-prefix=/app,api

And a response that sets a cookie like:

    Set-Cookie: session=1; Secure; Path=/; Domain=example.com

Then for a request to `/app/something`, the client will actually receive a cookie header of:

    Set-Cookie: session=1; Secure; Path=/app; Domain=example.com

This feature is intended to make it easier to allow multiple, distinct applications to share the same domain by using different paths, without them accidentally clobbering each others' cookies.