### PR TITLE
Don't try to send the buffered response twice

### DIFF
--- a/internal/server/response_buffer_middleware.go
+++ b/internal/server/response_buffer_middleware.go
@@ -49,7 +49,6 @@ type bufferedResponseWriter struct {
 	hijacked      bool
 	headerWritten bool
 	bypass        bool
-	sent          bool
 }
 
 func (w *bufferedResponseWriter) Send() error {
@@ -57,15 +56,13 @@ func (w *bufferedResponseWriter) Send() error {
 		return ErrMaximumSizeExceeded
 	}
 
-	if w.hijacked || w.sent {
+	if w.hijacked || w.bypass {
 		return nil
 	}
 
 	if w.headerWritten {
 		w.ResponseWriter.WriteHeader(w.statusCode)
 	}
-
-	w.sent = true
 
 	return w.buffer.Send(w.ResponseWriter)
 }
@@ -101,8 +98,8 @@ func (w *bufferedResponseWriter) ShouldSwitchToUnbuffered() bool {
 }
 
 func (w *bufferedResponseWriter) SwitchToUnbuffered() {
-	w.bypass = true
 	_ = w.Send()
+	w.bypass = true
 }
 
 func (w *bufferedResponseWriter) Write(data []byte) (int, error) {


### PR DESCRIPTION
In the event of unbuffered responses (such as `Transfer-Encoding: chunked` or server-sent events) the `Send()` function is called twice: once when calling `WriteHeader` and switching to the unbuffered response mode and the second time from the middleware, after other `ServeHTTP` are finished.

When `ResponseWriter.WriteHeader()` is called twice, a warning is logged to `stdout`. Example on how to reproduce this:

```go
package main

import (
	"fmt"
	"net/http"

	"github.com/basecamp/kamal-proxy/internal/server"
)

func main() {
	mux := http.NewServeMux()

	mux.Handle("/", server.WithResponseBufferMiddleware(1024, 1024, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		w.Header().Set("Transfer-Encoding", "chunked")
		w.WriteHeader(200)

		w.Write([]byte("foo"))
		w.Write([]byte("bar"))
		w.Write([]byte("\n"))
	})))

	fmt.Println("curl -v http://localhost:3000/")
	http.ListenAndServe(":3000", mux)
}
```

When running the server and making a request this warning will appear in the terminal:

`2025/12/17 13:03:31 http: superfluous response.WriteHeader call from github.com/basecamp/kamal-proxy/internal/server.(*bufferedResponseWriter).Send (response_buffer_middleware.go:65)`

Let me know if the PR is fine or if I need to change anything. / cc @kevinmcconnell 