### PR TITLE
Reduce default writer affinity to 1s

### DIFF
--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -32,7 +32,7 @@ const (
 	DefaultDeployTimeout         = time.Second * 30
 	DefaultDrainTimeout          = time.Second * 30
 	DefaultPauseTimeout          = time.Second * 30
-	DefaultWriterAffinityTimeout = time.Second * 3
+	DefaultWriterAffinityTimeout = time.Second
 
 	DefaultHealthCheckPath     = "/up"
 	DefaultHealthCheckPort     = 0


### PR DESCRIPTION
Our previous default was longer than many setups would need, so let's default to something a little more optimistic.