### PR TITLE
make socket path configurable

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -23,7 +23,7 @@ type Config struct {
 }
 
 func (c Config) SocketPath() string {
-	return path.Join(c.runtimeDirectory(), "kamal-proxy.sock")
+	return cmp.Or(os.Getenv("KAMAL_PROXY_SOCKET"), path.Join(c.runtimeDirectory(), "kamal-proxy.sock"))
 }
 
 func (c Config) StatePath() string {


### PR DESCRIPTION
Read the envvar KAMAL_PROXY_SOCKET to determine the control socket path.
This makes it possible to control a running kamal-proxy instance from a
different user, by making the socket accessible via file system
permissions.

If KAMAL_PROXY_SOCKET is unset, retain the previous
${XDG_RUNTIME_DIR:/tmp}/kamal-proxy.sock
behaviour.
