### PR TITLE
Validate redirect host to prevent open redirect via Host header

### DIFF
--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -507,8 +507,8 @@ func (s *Service) redirectURLIfNeeded(r *http.Request) string {
 	}
 
 	desiredHost := host
-	if s.options.CanonicalHost != "" && host != s.options.CanonicalHost {
-		desiredHost = s.options.CanonicalHost
+	if c := s.options.CanonicalHost; c != "" && !isWildcardHost(c) && host != c {
+		desiredHost = c
 	}
 
 	if desiredScheme == currentScheme && desiredHost == host {
@@ -533,35 +533,53 @@ func (s *Service) redirectURLIfNeeded(r *http.Request) string {
 
 // safeRedirectHost returns a host we are configured to serve, so that a
 // redirect's Location header can never be set to an arbitrary, client-supplied
-// Host. The explicit canonical host is always trusted; a request host that
-// matches one of the configured hosts (including a wildcard pattern) is kept
-// as-is. Otherwise we fall back to the canonical host or the first concrete
-// configured host, and if there is none we return an empty string so the caller
+// Host. A request host we serve (the canonical host or a configured host,
+// including a wildcard pattern) is kept as-is. Otherwise we fall back to a
+// concrete host we control — the canonical host or the first configured host —
+// never a wildcard pattern, which is a match rule rather than a valid redirect
+// target. If there is no concrete host we return an empty string so the caller
 // skips the redirect rather than reflecting the request's Host.
 func (s *Service) safeRedirectHost(host string) string {
-	if s.options.CanonicalHost != "" && hostMatchesPattern(host, s.options.CanonicalHost) {
+	if s.hostIsServed(host) {
 		return host
 	}
-	for _, h := range s.options.Hosts {
-		if h != "" && hostMatchesPattern(host, h) {
-			return host
-		}
-	}
 
-	if s.options.CanonicalHost != "" {
-		return s.options.CanonicalHost
+	if c := s.options.CanonicalHost; c != "" && !isWildcardHost(c) {
+		return c
 	}
 	for _, h := range s.options.Hosts {
-		if h != "" && !strings.HasPrefix(h, "*.") {
+		if h != "" && !isWildcardHost(h) {
 			return h
 		}
 	}
 	return ""
 }
 
-// hostMatchesPattern reports whether host matches a configured host pattern,
-// mirroring ServiceMap.bindingsForHost: an exact (case-insensitive) match, or a
-// single-label wildcard such as "*.example.com" matching "<label>.example.com".
+// hostIsServed reports whether host is one this service is configured to serve:
+// the canonical host or a configured host, matched by hostMatchesPattern.
+func (s *Service) hostIsServed(host string) bool {
+	if host == "" {
+		return false
+	}
+	if s.options.CanonicalHost != "" && hostMatchesPattern(host, s.options.CanonicalHost) {
+		return true
+	}
+	for _, h := range s.options.Hosts {
+		if h != "" && hostMatchesPattern(host, h) {
+			return true
+		}
+	}
+	return false
+}
+
+func isWildcardHost(host string) bool {
+	return strings.HasPrefix(host, "*.")
+}
+
+// hostMatchesPattern reports whether host matches a configured host pattern: an
+// exact match, or a single-label wildcard such as "*.example.com" matching
+// "<label>.example.com" — the same wildcard structure ServiceMap.bindingsForHost
+// uses for routing. Matching is case-insensitive, as host names are.
 func hostMatchesPattern(host, pattern string) bool {
 	if strings.EqualFold(host, pattern) {
 		return true

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -511,9 +511,42 @@ func (s *Service) redirectURLIfNeeded(r *http.Request) string {
 		desiredHost = s.options.CanonicalHost
 	}
 
-	if desiredScheme != currentScheme || desiredHost != host {
-		return desiredScheme + "://" + desiredHost + r.URL.RequestURI()
+	if desiredScheme == currentScheme && desiredHost == host {
+		return ""
 	}
 
-	return ""
+	// Never reflect an unvalidated, client-supplied Host header into the
+	// redirect target. A request can reach a service via a catch-all binding
+	// with an arbitrary Host, and echoing it here would turn the HTTPS or
+	// canonical-host redirect into an open redirect (CWE-601). Pin the redirect
+	// to a host we are actually configured to serve.
+	desiredHost = s.safeRedirectHost(desiredHost)
+
+	return desiredScheme + "://" + desiredHost + r.URL.RequestURI()
+}
+
+// safeRedirectHost returns a host we are configured to serve, so that a
+// redirect's Location header can never be set to an arbitrary, client-supplied
+// Host. The explicit canonical host is always trusted; otherwise the host must
+// match one of the service's configured hosts. When it doesn't, we fall back to
+// the canonical host or the first configured host rather than reflecting the
+// request's Host header.
+func (s *Service) safeRedirectHost(host string) string {
+	if s.options.CanonicalHost != "" && strings.EqualFold(host, s.options.CanonicalHost) {
+		return host
+	}
+	for _, h := range s.options.Hosts {
+		if h != "" && strings.EqualFold(host, h) {
+			return host
+		}
+	}
+	if s.options.CanonicalHost != "" {
+		return s.options.CanonicalHost
+	}
+	for _, h := range s.options.Hosts {
+		if h != "" {
+			return h
+		}
+	}
+	return host
 }

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -521,32 +521,55 @@ func (s *Service) redirectURLIfNeeded(r *http.Request) string {
 	// canonical-host redirect into an open redirect (CWE-601). Pin the redirect
 	// to a host we are actually configured to serve.
 	desiredHost = s.safeRedirectHost(desiredHost)
+	if desiredHost == "" {
+		// No host we are configured to serve to redirect to (e.g. a catch-all
+		// service with no concrete host). Skip the redirect rather than emit a
+		// malformed or client-controlled Location.
+		return ""
+	}
 
 	return desiredScheme + "://" + desiredHost + r.URL.RequestURI()
 }
 
 // safeRedirectHost returns a host we are configured to serve, so that a
 // redirect's Location header can never be set to an arbitrary, client-supplied
-// Host. The explicit canonical host is always trusted; otherwise the host must
-// match one of the service's configured hosts. When it doesn't, we fall back to
-// the canonical host or the first configured host rather than reflecting the
-// request's Host header.
+// Host. The explicit canonical host is always trusted; a request host that
+// matches one of the configured hosts (including a wildcard pattern) is kept
+// as-is. Otherwise we fall back to the canonical host or the first concrete
+// configured host, and if there is none we return an empty string so the caller
+// skips the redirect rather than reflecting the request's Host.
 func (s *Service) safeRedirectHost(host string) string {
-	if s.options.CanonicalHost != "" && strings.EqualFold(host, s.options.CanonicalHost) {
+	if s.options.CanonicalHost != "" && hostMatchesPattern(host, s.options.CanonicalHost) {
 		return host
 	}
 	for _, h := range s.options.Hosts {
-		if h != "" && strings.EqualFold(host, h) {
+		if h != "" && hostMatchesPattern(host, h) {
 			return host
 		}
 	}
+
 	if s.options.CanonicalHost != "" {
 		return s.options.CanonicalHost
 	}
 	for _, h := range s.options.Hosts {
-		if h != "" {
+		if h != "" && !strings.HasPrefix(h, "*.") {
 			return h
 		}
 	}
-	return host
+	return ""
+}
+
+// hostMatchesPattern reports whether host matches a configured host pattern,
+// mirroring ServiceMap.bindingsForHost: an exact (case-insensitive) match, or a
+// single-label wildcard such as "*.example.com" matching "<label>.example.com".
+func hostMatchesPattern(host, pattern string) bool {
+	if strings.EqualFold(host, pattern) {
+		return true
+	}
+	if strings.HasPrefix(pattern, "*.") {
+		if sep := strings.Index(host, "."); sep > 0 {
+			return strings.EqualFold("*"+host[sep:], pattern)
+		}
+	}
+	return false
 }

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -73,6 +73,54 @@ func TestService_RedirectPrefersCanonicalHostOverSpoofedHost(t *testing.T) {
 	require.Equal(t, "https://www.example.com/path", w.Result().Header.Get("Location"))
 }
 
+func TestService_HostMatchesPattern(t *testing.T) {
+	cases := []struct {
+		host, pattern string
+		want          bool
+	}{
+		{"example.com", "example.com", true},
+		{"EXAMPLE.com", "example.com", true},        // case-insensitive
+		{"app.example.com", "*.example.com", true},  // single-label wildcard
+		{"example.com", "*.example.com", false},     // apex doesn't match wildcard
+		{"a.b.example.com", "*.example.com", false}, // multi-label (mirrors bindingsForHost)
+		{"evil.net", "example.com", false},
+		{"example.com", "*.other.com", false},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, hostMatchesPattern(c.host, c.pattern), "hostMatchesPattern(%q, %q)", c.host, c.pattern)
+	}
+}
+
+func TestService_SafeRedirectHost(t *testing.T) {
+	cases := []struct {
+		name    string
+		options ServiceOptions
+		host    string
+		want    string
+	}{
+		{"configured host kept", ServiceOptions{Hosts: []string{"example.com"}}, "example.com", "example.com"},
+		{"unconfigured host pinned to configured", ServiceOptions{Hosts: []string{"example.com"}}, "evil.example.net", "example.com"},
+		{"wildcard preserves concrete subdomain", ServiceOptions{Hosts: []string{"*.example.com"}}, "app.example.com", "app.example.com"},
+		{"wildcard-only, non-matching host skips", ServiceOptions{Hosts: []string{"*.example.com"}}, "evil.net", ""},
+		{"canonical preferred over spoof", ServiceOptions{Hosts: []string{"example.com"}, CanonicalHost: "www.example.com"}, "evil.net", "www.example.com"},
+		{"catch-all only skips (no reflect)", ServiceOptions{Hosts: []string{""}}, "evil.net", ""},
+		{"no hosts skips", ServiceOptions{}, "evil.net", ""},
+	}
+	for _, c := range cases {
+		service := &Service{options: c.options}
+		require.Equal(t, c.want, service.safeRedirectHost(c.host), c.name)
+	}
+}
+
+func TestService_RedirectURLSkippedWhenNoSafeHost(t *testing.T) {
+	// A catch-all service (no concrete configured host) with TLS redirect must
+	// not emit a malformed https:/// Location built from the client Host — it
+	// skips the redirect instead.
+	service := &Service{options: ServiceOptions{Hosts: []string{""}, TLSEnabled: true, TLSRedirect: true}}
+	req := httptest.NewRequest(http.MethodGet, "http://evil.example.net/path", nil)
+	require.Equal(t, "", service.redirectURLIfNeeded(req))
+}
+
 func TestService_DontRedirectToHTTPSWhenTLSAndPlainHTTPAllowed(t *testing.T) {
 	var forwardedProto string
 

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -105,6 +105,7 @@ func TestService_SafeRedirectHost(t *testing.T) {
 		{"canonical preferred over spoof", ServiceOptions{Hosts: []string{"example.com"}, CanonicalHost: "www.example.com"}, "evil.net", "www.example.com"},
 		{"catch-all only skips (no reflect)", ServiceOptions{Hosts: []string{""}}, "evil.net", ""},
 		{"no hosts skips", ServiceOptions{}, "evil.net", ""},
+		{"wildcard canonical never returned as literal", ServiceOptions{Hosts: []string{"example.com"}, CanonicalHost: "*.example.com"}, "evil.net", "example.com"},
 	}
 	for _, c := range cases {
 		service := &Service{options: c.options}
@@ -119,6 +120,15 @@ func TestService_RedirectURLSkippedWhenNoSafeHost(t *testing.T) {
 	service := &Service{options: ServiceOptions{Hosts: []string{""}, TLSEnabled: true, TLSRedirect: true}}
 	req := httptest.NewRequest(http.MethodGet, "http://evil.example.net/path", nil)
 	require.Equal(t, "", service.redirectURLIfNeeded(req))
+}
+
+func TestService_RedirectIgnoresWildcardCanonicalHost(t *testing.T) {
+	// A wildcard is a match rule, not a redirect target: a (mis)configured
+	// wildcard CanonicalHost must never appear in the Location.
+	service := &Service{options: ServiceOptions{Hosts: []string{"example.com"}, CanonicalHost: "*.example.com", TLSEnabled: true, TLSRedirect: true}}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/p", nil)
+	require.Equal(t, "https://example.com/p", service.redirectURLIfNeeded(req))
 }
 
 func TestService_DontRedirectToHTTPSWhenTLSAndPlainHTTPAllowed(t *testing.T) {

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -43,6 +43,36 @@ func TestService_RedirectToHTTPSWhenTLSRequired(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)
 }
 
+func TestService_RedirectDoesNotReflectUnconfiguredHost(t *testing.T) {
+	// A request can reach a service via a catch-all binding carrying an
+	// arbitrary Host header. The HTTPS redirect must not echo that host into
+	// the Location header, or it becomes an open redirect (CWE-601). The
+	// redirect target must be pinned to a host we are configured to serve.
+	service := testCreateService(t, ServiceOptions{Hosts: []string{"example.com"}, TLSEnabled: true, TLSRedirect: true}, defaultTargetOptions)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/path?q=1", nil)
+	req.Host = "evil.example.net"
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusMovedPermanently, w.Result().StatusCode)
+	require.Equal(t, "https://example.com/path?q=1", w.Result().Header.Get("Location"))
+}
+
+func TestService_RedirectPrefersCanonicalHostOverSpoofedHost(t *testing.T) {
+	// With a canonical host configured, a spoofed Host must still resolve to the
+	// canonical host rather than being reflected.
+	service := testCreateService(t, ServiceOptions{Hosts: []string{"example.com"}, CanonicalHost: "www.example.com", TLSEnabled: true, TLSRedirect: true}, defaultTargetOptions)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/path", nil)
+	req.Host = "evil.example.net"
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusMovedPermanently, w.Result().StatusCode)
+	require.Equal(t, "https://www.example.com/path", w.Result().Header.Get("Location"))
+}
+
 func TestService_DontRedirectToHTTPSWhenTLSAndPlainHTTPAllowed(t *testing.T) {
 	var forwardedProto string
 


### PR DESCRIPTION
## What

`Service.redirectURLIfNeeded` built the HTTPS / canonical-host redirect `Location` from the client-supplied `Host` header without validating it against the service's configured hosts. A request that reaches a service via a catch-all binding with a spoofed `Host` could be reflected into the `Location` header, producing an **open redirect (CWE-601)**.

This mirrors the same hardening applied to Thruster's HTTP→HTTPS redirect (validate `Host` against the configured domains).

## Fix

Pin the redirect target to a host we are actually configured to serve:

- the explicit `CanonicalHost` is always trusted;
- otherwise the host must match one of the service's configured `Hosts` (case-insensitive);
- on mismatch, fall back to the canonical host or the first configured host rather than echoing the request's `Host`.

The sanitization is applied only on the redirect path, so normal same-host / canonical-host behavior is unchanged.

## Severity

Defense-in-depth. A deployable configuration is hard to exploit in practice:

- a catch-all service (`""` host) cannot enable TLS (`host must be set when using TLS` is rejected at deploy time), so the TLS-redirect path can't fire for it;
- a mismatched `Host` on a properly-configured service falls through to `requestServiceMap[""]` and 404s before reaching the redirect;
- browsers set `Host` to match the URL, so there's no spoof without a MITM.

Still, the `Location` should never be derived from an unvalidated `Host`.

Reported as `GHSA-f438-cfww-34vx`.

## Tests

- `TestService_RedirectDoesNotReflectUnconfiguredHost` — spoofed `Host` is not reflected; redirect pins to the configured host.
- `TestService_RedirectPrefersCanonicalHostOverSpoofedHost` — with a canonical host configured, a spoofed `Host` resolves to the canonical host.
- Existing redirect tests (`TestService_RedirectToHTTPSWhenTLSRequired`, …) still pass; full suite green.