### PR TITLE
On-demand TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,33 @@ root path. Services deployed to other paths on the same host will use the same
 TLS settings as those specified for the root path.
 
 
+### On-demand TLS
+
+Instead of specifying a static list of hosts, Kamal Proxy can also obtain TLS
+certificates dynamically, for any host approved by an HTTP endpoint of your
+choice. This is useful when the full set of hosts is not known at deploy time,
+such as when serving customer domains.
+
+To enable this, specify `--tls-on-demand-url` (instead of `--host`) when
+deploying:
+
+    kamal-proxy deploy service1 --target web-1:3000 --tls --tls-on-demand-url="http://localhost:4567/check"
+
+The URL may be:
+
+- An external URL (like `http://localhost:4567/check`), which Kamal Proxy will
+  call directly, or
+- A path (like `/check`), which Kamal Proxy will route through the service to
+  your application, letting the application decide which hosts to allow.
+
+Before issuing a certificate for a host, Kamal Proxy will send a `GET` request
+to the endpoint, with the hostname in a `host` query parameter (for example,
+`?host=app1.example.com`) and matching `Host` header. A `200` response allows
+certificate issuance; any other response denies it, and the status code and up
+to 256 bytes of the response body are logged to help with debugging. Checks
+time out after 2 seconds, denying issuance for that attempt.
+
+
 ### Custom TLS certificate
 
 When you obtained your TLS certificate manually, manage your own certificate authority,

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -33,6 +33,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.StripPrefix, "strip-path-prefix", true, "With --path-prefix, strip prefix from request before forwarding")
 
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSEnabled, "tls", false, "Configure TLS for this target (requires a non-empty host)")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSOnDemandURL, "tls-on-demand-url", "", "Will make an HTTP request to the given URL, asking whether a host is allowed to have a certificate issued")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "Configure custom TLS certificate path (PEM format)")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "Configure custom TLS private key path (PEM format)")

--- a/internal/cmd/deploy_test.go
+++ b/internal/cmd/deploy_test.go
@@ -36,6 +36,37 @@ func TestDeployCommand_TLSRequiresHost(t *testing.T) {
 	assertTLSHostValidation(t, []string{"example.com", "*.example.com"}, true)
 }
 
+func TestDeployCommand_TLSOnDemandURL(t *testing.T) {
+	t.Run("host is not required when a TLS on-demand URL is set", func(t *testing.T) {
+		cmd := newDeployCommand()
+		cmd.args.ServiceOptions.TLSEnabled = true
+		cmd.args.ServiceOptions.TLSOnDemandURL = "https://example.com/allow-host"
+
+		require.NoError(t, cmd.preRun(cmd.cmd, []string{"test-service"}))
+	})
+
+	t.Run("hosts cannot be combined with a TLS on-demand URL", func(t *testing.T) {
+		cmd := newDeployCommand()
+		cmd.args.ServiceOptions.TLSEnabled = true
+		cmd.args.ServiceOptions.TLSOnDemandURL = "https://example.com/allow-host"
+		cmd.args.ServiceOptions.Hosts = []string{"example.com"}
+
+		err := cmd.preRun(cmd.cmd, []string{"test-service"})
+		require.ErrorContains(t, err, "cannot set hosts when using a TLS on-demand URL")
+		require.ErrorIs(t, err, server.ErrServiceOptionsInvalid)
+	})
+
+	t.Run("the TLS on-demand URL must be valid", func(t *testing.T) {
+		cmd := newDeployCommand()
+		cmd.args.ServiceOptions.TLSEnabled = true
+		cmd.args.ServiceOptions.TLSOnDemandURL = "ftp://example.com/allow-host"
+
+		err := cmd.preRun(cmd.cmd, []string{"test-service"})
+		require.ErrorContains(t, err, "unsupported scheme")
+		require.ErrorIs(t, err, server.ErrServiceOptionsInvalid)
+	})
+}
+
 func TestDeployCommand_CanonicalHostValidation(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"net/http"
@@ -10,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -801,6 +804,41 @@ func TestRouter_RestoreLastSavedState(t *testing.T) {
 	statusCode, body = sendGETRequest(router, "https://other.example.com/api")
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "third", body)
+}
+
+func TestRouter_RestoreLastSavedState_TLSOnDemandURL(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+
+	allowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("host") == "allowed.example.com" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer allowServer.Close()
+
+	_, target := testBackend(t, "first", http.StatusOK)
+
+	serviceOptions := defaultServiceOptions
+	serviceOptions.TLSEnabled = true
+	serviceOptions.TLSOnDemandURL = allowServer.URL
+
+	router := NewRouter(statePath)
+	require.NoError(t, router.DeployService("ondemand", []string{target}, defaultEmptyReaders, serviceOptions, defaultTargetOptions, defaultDeploymentOptions))
+
+	router = NewRouter(statePath)
+	require.NoError(t, router.RestoreLastSavedState())
+
+	service := router.services.Get("ondemand")
+	require.NotNil(t, service)
+
+	manager, ok := service.certManager.(*autocert.Manager)
+	require.True(t, ok)
+	require.NotNil(t, manager.HostPolicy)
+
+	assert.NoError(t, manager.HostPolicy(context.Background(), "allowed.example.com"))
+	assert.Error(t, manager.HostPolicy(context.Background(), "denied.example.com"))
 }
 
 // Helpers

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -56,7 +57,21 @@ var (
 	ErrorUnableToLoadErrorPages              = errors.New("unable to load error pages")
 	ErrorAutomaticTLSDoesNotSupportWildcards = errors.New("automatic TLS does not support wildcards")
 	ErrServiceOptionsInvalid                 = errors.New("service options invalid")
+
+	contextKeyInternalRequest = contextKey("internal-request")
 )
+
+// markInternalRequest marks the context as belonging to an internal request:
+// one synthesized inside the proxy itself, such as a TLS on-demand check
+// probe, rather than arriving over a client connection.
+func markInternalRequest(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKeyInternalRequest, true)
+}
+
+func isInternalRequest(r *http.Request) bool {
+	internal, _ := r.Context().Value(contextKeyInternalRequest).(bool)
+	return internal
+}
 
 type TargetSlot int
 
@@ -85,6 +100,7 @@ type ServiceOptions struct {
 	TLSEnabled                  bool          `json:"tls_enabled"`
 	TLSCertificatePath          string        `json:"tls_certificate_path"`
 	TLSPrivateKeyPath           string        `json:"tls_private_key_path"`
+	TLSOnDemandURL              string        `json:"tls_on_demand_url"`
 	TLSRedirect                 bool          `json:"tls_redirect"`
 	CanonicalHost               string        `json:"canonical_host"`
 	ACMEDirectory               string        `json:"acme_directory"`
@@ -109,8 +125,28 @@ func (so *ServiceOptions) Normalize() {
 func (so ServiceOptions) Validate() error {
 	so.Normalize()
 
+	if so.TLSOnDemandURL != "" && !so.TLSEnabled {
+		return fmt.Errorf("%w: TLS must be enabled to use a TLS on-demand URL", ErrServiceOptionsInvalid)
+	}
+
 	if so.TLSEnabled {
-		if !so.HasConfiguredHosts() {
+		if so.TLSOnDemandURL != "" {
+			if so.HasConfiguredHosts() {
+				return fmt.Errorf("%w: cannot set hosts when using a TLS on-demand URL", ErrServiceOptionsInvalid)
+			}
+
+			if so.TLSCertificatePath != "" || so.TLSPrivateKeyPath != "" {
+				return fmt.Errorf("%w: cannot use a custom TLS certificate with a TLS on-demand URL", ErrServiceOptionsInvalid)
+			}
+
+			if so.CanonicalHost != "" {
+				return fmt.Errorf("%w: cannot set a canonical host when using a TLS on-demand URL", ErrServiceOptionsInvalid)
+			}
+
+			if err := validateTLSOnDemandURL(so.TLSOnDemandURL); err != nil {
+				return fmt.Errorf("%w: %w", ErrServiceOptionsInvalid, err)
+			}
+		} else if !so.HasConfiguredHosts() {
 			return fmt.Errorf("%w: host must be set when using TLS", ErrServiceOptionsInvalid)
 		}
 
@@ -430,12 +466,31 @@ func (s *Service) createCertManager(options ServiceOptions) (CertManager, error)
 		}
 	}
 
+	certCache := autocert.DirCache(options.ScopedCachePath())
+
+	hostPolicy, err := s.createHostPolicy(options, certCache)
+	if err != nil {
+		return nil, err
+	}
+
 	return &autocert.Manager{
 		Prompt:     autocert.AcceptTOS,
-		Cache:      autocert.DirCache(options.ScopedCachePath()),
-		HostPolicy: autocert.HostWhitelist(options.Hosts...),
+		Cache:      certCache,
+		HostPolicy: hostPolicy,
 		Client:     &acme.Client{DirectoryURL: options.ACMEDirectory},
 	}, nil
+}
+
+func (s *Service) createHostPolicy(options ServiceOptions, certCache autocert.Cache) (autocert.HostPolicy, error) {
+	if options.TLSOnDemandURL != "" {
+		checker, err := newTLSOnDemandChecker(s, options.TLSOnDemandURL, certCache)
+		if err != nil {
+			return nil, err
+		}
+		return checker.hostPolicy(), nil
+	}
+
+	return autocert.HostWhitelist(options.Hosts...), nil
 }
 
 func (s *Service) createMiddleware(options ServiceOptions, certManager CertManager) (http.Handler, error) {
@@ -533,28 +588,30 @@ func (s *Service) handleRedirectsIfNeeded(w http.ResponseWriter, r *http.Request
 // TLS redirection or canonical host redirection should occur. If no redirect is
 // needed, it returns an empty string.
 func (s *Service) redirectURLIfNeeded(r *http.Request) string {
-	host, _, err := net.SplitHostPort(r.Host)
-	if err != nil {
-		host = r.Host
-	}
+	if !isInternalRequest(r) {
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			host = r.Host
+		}
 
-	currentScheme := "http"
-	if r.TLS != nil {
-		currentScheme = "https"
-	}
+		currentScheme := "http"
+		if r.TLS != nil {
+			currentScheme = "https"
+		}
 
-	desiredScheme := currentScheme
-	if s.options.TLSEnabled && s.options.TLSRedirect && currentScheme == "http" {
-		desiredScheme = "https"
-	}
+		desiredScheme := currentScheme
+		if s.options.TLSEnabled && s.options.TLSRedirect && currentScheme == "http" {
+			desiredScheme = "https"
+		}
 
-	desiredHost := host
-	if s.options.CanonicalHost != "" && host != s.options.CanonicalHost {
-		desiredHost = s.options.CanonicalHost
-	}
+		desiredHost := host
+		if s.options.CanonicalHost != "" && host != s.options.CanonicalHost {
+			desiredHost = s.options.CanonicalHost
+		}
 
-	if desiredScheme != currentScheme || desiredHost != host {
-		return desiredScheme + "://" + desiredHost + r.URL.RequestURI()
+		if desiredScheme != currentScheme || desiredHost != host {
+			return desiredScheme + "://" + desiredHost + r.URL.RequestURI()
+		}
 	}
 
 	return ""

--- a/internal/server/service_map.go
+++ b/internal/server/service_map.go
@@ -155,7 +155,7 @@ func (m *ServiceMap) updateRequestServiceMap() {
 
 func (m *ServiceMap) updateDefaultTLSHostname() {
 	for _, service := range m.services {
-		if service.options.TLSEnabled && len(service.options.Hosts) > 0 {
+		if service.options.TLSEnabled && len(service.options.Hosts) > 0 && service.options.Hosts[0] != "" {
 			m.defaultTLSHostname = service.options.Hosts[0]
 			return
 		}

--- a/internal/server/service_map_test.go
+++ b/internal/server/service_map_test.go
@@ -81,6 +81,19 @@ func TestServiceMap_DefaultTLSHostname(t *testing.T) {
 	assert.Equal(t, "example.com", sm.DefaultTLSHostname())
 }
 
+func TestServiceMap_DefaultTLSHostnameIgnoresOnDemandTLSServices(t *testing.T) {
+	sm := NewServiceMap()
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "/allow-host"})})
+	assert.Empty(t, sm.DefaultTLSHostname())
+
+	sm.Set(&Service{name: "2", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"example.com"}, TLSEnabled: true})})
+	assert.Equal(t, "example.com", sm.DefaultTLSHostname())
+
+	// Re-setting the on-demand service must not displace the default hostname.
+	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "/allow-host"})})
+	assert.Equal(t, "example.com", sm.DefaultTLSHostname())
+}
+
 func TestServiceMap_SyncingTLSSettingsFromRootPath(t *testing.T) {
 	sm := NewServiceMap()
 	sm.Set(&Service{name: "1", options: normalizedServiceOptions(ServiceOptions{Hosts: []string{"1.example.com"}, TLSEnabled: true, TLSRedirect: false})})

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -121,6 +121,17 @@ func TestServiceOptions_Validate(t *testing.T) {
 
 	assertNotValid(ServiceOptions{Hosts: []string{"example.com", "www.example.com"}, CanonicalHost: "api.example.com"}, "canonical-host 'api.example.com' must be present in the hosts list: [example.com www.example.com]")
 	assertValid(ServiceOptions{Hosts: []string{"example.com", "www.example.com"}, CanonicalHost: "www.example.com"})
+
+	assertValid(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "/allow-host"})
+	assertValid(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "https://example.com/allow-host"})
+	assertNotValid(ServiceOptions{Hosts: []string{"example.com"}, TLSEnabled: true, TLSOnDemandURL: "/allow-host"}, "cannot set hosts when using a TLS on-demand URL")
+	assertNotValid(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "ftp://example.com/allow-host"}, "unsupported scheme")
+	assertNotValid(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "://invalid-url"}, "unable to parse tls-on-demand-url")
+	assertNotValid(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "//example.com/allow-host"}, "must be a path or an absolute http(s) URL")
+	assertNotValid(ServiceOptions{PathPrefixes: []string{"/api"}, TLSEnabled: true, TLSOnDemandURL: "/allow-host"}, "TLS settings must be specified on the root path service")
+	assertNotValid(ServiceOptions{TLSOnDemandURL: "/allow-host"}, "TLS must be enabled to use a TLS on-demand URL")
+	assertNotValid(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "/allow-host", TLSCertificatePath: "cert.pem", TLSPrivateKeyPath: "key.pem"}, "cannot use a custom TLS certificate with a TLS on-demand URL")
+	assertNotValid(ServiceOptions{TLSEnabled: true, TLSOnDemandURL: "/allow-host", CanonicalHost: "example.com"}, "cannot set a canonical host when using a TLS on-demand URL")
 }
 
 func TestService_DontRedirectToHTTPSWhenTLSAndPlainHTTPAllowed(t *testing.T) {

--- a/internal/server/tls_on_demand.go
+++ b/internal/server/tls_on_demand.go
@@ -1,0 +1,222 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+const (
+	tlsOnDemandCheckTimeout      = 2 * time.Second
+	tlsOnDemandCheckMaxBodyBytes = 256
+)
+
+// tlsOnDemandChecker builds an autocert.HostPolicy that approves hosts by
+// querying the configured TLS on-demand endpoint (with a `host` query
+// parameter); a 200 response allows certificate issuance.
+type tlsOnDemandChecker struct {
+	service   *Service
+	certCache autocert.Cache
+	endpoint  *url.URL
+	local     bool // endpoint is a path served by the service itself
+
+	checkTimeout time.Duration
+}
+
+func newTLSOnDemandChecker(service *Service, onDemandURL string, certCache autocert.Cache) (*tlsOnDemandChecker, error) {
+	endpoint, local, err := parseTLSOnDemandURL(onDemandURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tlsOnDemandChecker{
+		service:      service,
+		certCache:    certCache,
+		endpoint:     endpoint,
+		local:        local,
+		checkTimeout: tlsOnDemandCheckTimeout,
+	}, nil
+}
+
+// parseTLSOnDemandURL parses a TLS on-demand URL, returning the parsed URL and
+// whether it names a path on the service itself rather than an external
+// endpoint.
+func parseTLSOnDemandURL(onDemandURL string) (*url.URL, bool, error) {
+	if strings.HasPrefix(onDemandURL, "//") {
+		return nil, false, fmt.Errorf("tls-on-demand-url must be a path or an absolute http(s) URL")
+	}
+
+	if strings.HasPrefix(onDemandURL, "/") {
+		endpoint, err := url.Parse(onDemandURL)
+		if err != nil {
+			return nil, false, fmt.Errorf("unable to parse tls-on-demand-url: %w", err)
+		}
+		return endpoint, true, nil
+	}
+
+	endpoint, err := url.ParseRequestURI(onDemandURL)
+	if err != nil {
+		return nil, false, fmt.Errorf("unable to parse tls-on-demand-url: %w", err)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return nil, false, fmt.Errorf("unsupported scheme %q in tls-on-demand-url", endpoint.Scheme)
+	}
+	if endpoint.Host == "" {
+		return nil, false, fmt.Errorf("missing host in tls-on-demand-url")
+	}
+	return endpoint, false, nil
+}
+
+func validateTLSOnDemandURL(onDemandURL string) error {
+	_, _, err := parseTLSOnDemandURL(onDemandURL)
+	return err
+}
+
+func (c *tlsOnDemandChecker) hostPolicy() autocert.HostPolicy {
+	policy := c.externalHostPolicy()
+	if c.local {
+		policy = c.localHostPolicy()
+	}
+
+	return func(ctx context.Context, host string) error {
+		// Since x/crypto v0.34.0, autocert consults the host policy on every
+		// handshake, not just when issuing a certificate. A host that
+		// already has a certificate was approved when that certificate was
+		// issued, so we skip re-checking it. This keeps the endpoint off the
+		// handshake hot path, and means an endpoint outage cannot affect
+		// hosts that already serve TLS.
+		if c.hasCachedCert(ctx, host) {
+			return nil
+		}
+
+		return policy(ctx, host)
+	}
+}
+
+// hasCachedCert reports whether the certificate cache already holds a
+// certificate for the host. autocert stores certificates keyed by the
+// punycoded domain (which the host already is, by the time the policy is
+// called), with a "+rsa" variant for RSA-only clients.
+func (c *tlsOnDemandChecker) hasCachedCert(ctx context.Context, host string) bool {
+	host = strings.TrimSuffix(host, ".")
+
+	for _, key := range []string{host, host + "+rsa"} {
+		if _, err := c.certCache.Get(ctx, key); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// localHostPolicy approves hosts by routing a request for the configured path
+// through the service's own handler chain, so the backend application decides
+// which hosts are allowed.
+func (c *tlsOnDemandChecker) localHostPolicy() autocert.HostPolicy {
+	return func(ctx context.Context, host string) error {
+		ctx, cancel := context.WithTimeout(ctx, c.checkTimeout)
+		defer cancel()
+		ctx = markInternalRequest(ctx)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.checkURL(host), http.NoBody)
+		if err != nil {
+			return err
+		}
+
+		// The probe carries the hostname being validated, so backends that
+		// use host authorization see that rather than the target's address.
+		req.Host = host
+
+		recorder := newBoundedResponseRecorder(tlsOnDemandCheckMaxBodyBytes)
+		c.service.ServeHTTP(recorder, req)
+
+		if recorder.status != http.StatusOK {
+			return c.denialError(host, recorder.status, recorder.body.String())
+		}
+		return nil
+	}
+}
+
+// externalHostPolicy approves hosts by making an HTTP request to the
+// configured external endpoint.
+func (c *tlsOnDemandChecker) externalHostPolicy() autocert.HostPolicy {
+	client := &http.Client{
+		Timeout: c.checkTimeout,
+
+		// A redirect is the endpoint's final answer; following it could turn
+		// a denial into a 200 from wherever it redirects to.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	return func(ctx context.Context, host string) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.checkURL(host), http.NoBody)
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, tlsOnDemandCheckMaxBodyBytes))
+			return c.denialError(host, resp.StatusCode, string(body))
+		}
+		return nil
+	}
+}
+
+func (c *tlsOnDemandChecker) checkURL(host string) string {
+	endpoint := *c.endpoint
+
+	query := endpoint.Query()
+	query.Set("host", host)
+	endpoint.RawQuery = query.Encode()
+
+	return endpoint.String()
+}
+
+func (c *tlsOnDemandChecker) denialError(host string, status int, body string) error {
+	slog.Warn("TLS on-demand check denied host", "host", host, "status", status, "body", body)
+
+	return fmt.Errorf("%s is not allowed to get a certificate (status: %d, body: %q)", host, status, body)
+}
+
+// boundedResponseRecorder is an http.ResponseWriter that captures the response
+// status and at most `limit` bytes of the body, discarding the rest.
+type boundedResponseRecorder struct {
+	status int
+	body   bytes.Buffer
+	limit  int
+	header http.Header
+}
+
+func newBoundedResponseRecorder(limit int) *boundedResponseRecorder {
+	return &boundedResponseRecorder{status: http.StatusOK, limit: limit, header: http.Header{}}
+}
+
+func (r *boundedResponseRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *boundedResponseRecorder) WriteHeader(status int) {
+	r.status = status
+}
+
+func (r *boundedResponseRecorder) Write(p []byte) (int, error) {
+	if remaining := r.limit - r.body.Len(); remaining > 0 {
+		r.body.Write(p[:min(len(p), remaining)])
+	}
+	return len(p), nil
+}

--- a/internal/server/tls_on_demand_test.go
+++ b/internal/server/tls_on_demand_test.go
@@ -1,0 +1,252 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+func testHostPolicy(t *testing.T, service *Service, onDemandURL string) autocert.HostPolicy {
+	checker, err := newTLSOnDemandChecker(service, onDemandURL, autocert.DirCache(t.TempDir()))
+	require.NoError(t, err)
+	return checker.hostPolicy()
+}
+
+func TestTLSOnDemandChecker_LocalHostPolicy(t *testing.T) {
+	service := testCreateServiceWithHandler(
+		t,
+		ServiceOptions{TLSOnDemandURL: "/allow-host"},
+		defaultTargetOptions,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/up" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if r.URL.Path == "/allow-host" && r.URL.Query().Get("host") == "allowed.example.com" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("Access denied"))
+		}),
+	)
+
+	policy := testHostPolicy(t, service, service.options.TLSOnDemandURL)
+
+	assert.NoError(t, policy(context.Background(), "allowed.example.com"))
+
+	err := policy(context.Background(), "denied.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed to get a certificate")
+	assert.Contains(t, err.Error(), "status: 403")
+	assert.Contains(t, err.Error(), "Access denied")
+}
+
+func TestTLSOnDemandChecker_LocalHostPolicy_IsNotRedirectedWhenTLSRedirectEnabled(t *testing.T) {
+	var forwardedProto string
+
+	service := testCreateServiceWithHandler(
+		t,
+		ServiceOptions{
+			TLSEnabled:     true,
+			TLSRedirect:    true,
+			TLSOnDemandURL: "/allow-host",
+		},
+		defaultTargetOptions,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/up" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if r.URL.Path == "/allow-host" && r.URL.Query().Get("host") == "allowed.example.com" {
+				forwardedProto = r.Header.Get("X-Forwarded-Proto")
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusForbidden)
+		}),
+	)
+
+	policy := testHostPolicy(t, service, service.options.TLSOnDemandURL)
+
+	assert.NoError(t, policy(context.Background(), "allowed.example.com"))
+	assert.Equal(t, "http", forwardedProto)
+}
+
+func TestTLSOnDemandChecker_LocalHostPolicy_SetsHostHeaderToCheckedHost(t *testing.T) {
+	var checkHost string
+
+	service := testCreateServiceWithHandler(
+		t,
+		ServiceOptions{TLSOnDemandURL: "/allow-host"},
+		defaultTargetOptions,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/allow-host" {
+				checkHost = r.Host
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	policy := testHostPolicy(t, service, service.options.TLSOnDemandURL)
+
+	assert.NoError(t, policy(context.Background(), "allowed.example.com"))
+	assert.Equal(t, "allowed.example.com", checkHost)
+}
+
+func TestTLSOnDemandChecker_LocalHostPolicy_TruncatesLargeResponseBodies(t *testing.T) {
+	service := testCreateServiceWithHandler(
+		t,
+		ServiceOptions{TLSOnDemandURL: "/allow-host"},
+		defaultTargetOptions,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/up" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(strings.Repeat("a", 500)))
+		}),
+	)
+
+	policy := testHostPolicy(t, service, service.options.TLSOnDemandURL)
+
+	err := policy(context.Background(), "denied.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), strings.Repeat("a", 256))
+	assert.NotContains(t, err.Error(), strings.Repeat("a", 257))
+}
+
+func TestTLSOnDemandChecker_LocalHostPolicy_DeniesWhenStopped(t *testing.T) {
+	service := testCreateServiceWithHandler(
+		t,
+		ServiceOptions{TLSOnDemandURL: "/allow-host"},
+		defaultTargetOptions,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	policy := testHostPolicy(t, service, service.options.TLSOnDemandURL)
+
+	require.NoError(t, service.Stop(time.Second, "stopped for maintenance"))
+
+	err := policy(context.Background(), "allowed.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed to get a certificate")
+}
+
+func TestTLSOnDemandChecker_ExternalHostPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("host") == "allowed.example.com" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("Access denied"))
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	policy := testHostPolicy(t, service, server.URL)
+
+	assert.NoError(t, policy(context.Background(), "allowed.example.com"))
+
+	err := policy(context.Background(), "denied.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed to get a certificate")
+	assert.Contains(t, err.Error(), "status: 403")
+	assert.Contains(t, err.Error(), "Access denied")
+}
+
+func TestTLSOnDemandChecker_ExternalHostPolicy_DoesNotFollowRedirects(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/allowed" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, "/allowed", http.StatusFound)
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	policy := testHostPolicy(t, service, server.URL)
+
+	err := policy(context.Background(), "denied.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status: 302")
+}
+
+func TestTLSOnDemandChecker_ExternalHostPolicy_HonoursContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	service := &Service{}
+	policy := testHostPolicy(t, service, server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.Error(t, policy(ctx, "allowed.example.com"))
+}
+
+func TestTLSOnDemandChecker_SkipsCheckWhenHostAlreadyHasCert(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	// Certificates live in the cache keyed by domain, with a "+rsa" variant
+	// for RSA-only clients.
+	certCache := autocert.DirCache(t.TempDir())
+	require.NoError(t, certCache.Put(context.Background(), "cached.example.com", []byte("cert")))
+	require.NoError(t, certCache.Put(context.Background(), "rsa-only.example.com+rsa", []byte("cert")))
+
+	checker, err := newTLSOnDemandChecker(&Service{}, server.URL, certCache)
+	require.NoError(t, err)
+	policy := checker.hostPolicy()
+
+	assert.NoError(t, policy(context.Background(), "cached.example.com"))
+	assert.NoError(t, policy(context.Background(), "cached.example.com."))
+	assert.NoError(t, policy(context.Background(), "rsa-only.example.com"))
+	assert.Equal(t, 0, requests)
+
+	assert.Error(t, policy(context.Background(), "uncached.example.com"))
+	assert.Equal(t, 1, requests)
+}
+
+func TestTLSOnDemandChecker_CheckURL(t *testing.T) {
+	checkURL := func(onDemandURL, host string) string {
+		checker, err := newTLSOnDemandChecker(&Service{}, onDemandURL, autocert.DirCache(t.TempDir()))
+		require.NoError(t, err)
+		return checker.checkURL(host)
+	}
+
+	assert.Equal(t, "/allow-host?host=test.example.com", checkURL("/allow-host", "test.example.com"))
+	assert.Equal(t, "/allow-host?host=test.example.com%3A8080", checkURL("/allow-host", "test.example.com:8080"))
+	assert.Equal(t, "/allow-host?host=test.example.com&token=abc", checkURL("/allow-host?token=abc", "test.example.com"))
+	assert.Equal(t, "https://example.com/check?host=test.example.com&token=abc", checkURL("https://example.com/check?token=abc", "test.example.com"))
+}
+
+func TestValidateTLSOnDemandURL(t *testing.T) {
+	assert.NoError(t, validateTLSOnDemandURL("/allow-host"))
+	assert.NoError(t, validateTLSOnDemandURL("/allow-host?token=abc"))
+	assert.NoError(t, validateTLSOnDemandURL("http://example.com/check"))
+	assert.NoError(t, validateTLSOnDemandURL("https://example.com/check"))
+
+	assert.ErrorContains(t, validateTLSOnDemandURL("://invalid-url"), "unable to parse tls-on-demand-url")
+	assert.ErrorContains(t, validateTLSOnDemandURL("ftp://example.com/check"), "unsupported scheme")
+	assert.ErrorContains(t, validateTLSOnDemandURL("allow-host"), "unable to parse tls-on-demand-url")
+	assert.ErrorContains(t, validateTLSOnDemandURL("http://"), "missing host")
+	assert.ErrorContains(t, validateTLSOnDemandURL("//example.com/check"), "must be a path or an absolute http(s) URL")
+}


### PR DESCRIPTION
Allows applications to provision TLS certificates for multiple hosts on-demand, by way of an application endpoint that gates issuance on a host-by-host basis.

To use, specify `--tls-on-demand-url` rather than `--host`. The URL can be directed to an external service, or plain path routed to the service.

This is a port of #63, which had drifted a bit from `main` (and from `autocert`),