### PR TITLE
Bump the Go toolchain to 1.26.7 for six stdlib advisories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS build
+FROM golang:1.26.7 AS build
 
 WORKDIR /app
 

--- a/example/upstream/Dockerfile
+++ b/example/upstream/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.26.5 as build
+from golang:1.26.7 as build
 workdir /app
 copy . .
 env CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/kamal-proxy
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/coder/websocket v1.8.12


### PR DESCRIPTION
`govulncheck` against this tree on **go1.26.5** reports **six** Go standard library vulnerabilities, every one of them fixed in go1.26.6:

| ID | Package |
|---|---|
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` |
| [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091) | `html/template` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` |
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `net/http` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` |

**Nothing in the source changed** — `go.mod` pinned `go 1.26.5`, and the advisories landed against it.

GO-2026-6091 has a reachable trace through `internal/server/error_page_middleware.go:79:25` (`Template.Execute`). For a TLS-terminating HTTP proxy the `crypto/tls` and `net/http` findings warrant attention on their own merits, independent of reachability.

I found this while bumping `basecamp/cli` for the same advisories: cli runs a `govulncheck` job and went red, which prompted checking the other Go repos. This one has no such job, so it was silently affected rather than visibly broken. `once` and `basecamp-installer` are in the same position and have matching PRs.

### Verification

Same tree, toolchain swapped:

```
go1.26.5 → 6 vulnerabilities
go1.26.7 → No vulnerabilities found.
```

`go build`, `go vet`, `gofmt -l` and `go test ./...` (3 packages) all pass on 1.26.7.

Patch-pinning keeps the house pattern — `once` and `basecamp-installer` also patch-pin the `go` directive with no `toolchain` directive — and all setup-go steps here read `go-version-file: go.mod`, so the single line covers every job.

---

### Why this needed a human, and how to stop that

Nothing is going to bump this pin for us:

- **Dependabot does not update the Go `go`/`toolchain` directive.** It's an open feature request — [dependabot-core#13520](https://github.com/dependabot/dependabot-core/issues/13520), filed 2025-11-11, still open. Our `gomod` config groups and cools down *module* updates and never touches the toolchain.
- **GitHub raises no security alert for a vulnerable toolchain version in go.mod either**, per that same thread. So neither the version-update nor the security-update path covers it.
- `check-latest: true` on setup-go would not have saved us here: it re-resolves the *version spec*, so against an exact `1.26.7` it's a no-op. It only floats when the spec is a range (`1.26`, `stable`, `oldstable`).

That leaves a real choice, and it's worth making deliberately rather than by default:

| | reproducible | self-healing |
|---|---|---|
| patch-pin, as here (`go 1.26.7`) | ✅ | ❌ needs a manual bump |
| `go-version: stable` + `check-latest: true` | ❌ toolchain floats | ✅ |
| bare minor (`go 1.26`, no check-latest) | ❌ | ❌ |

The third row is the trap, and it's what `basecamp/cli` was on: the spec floats but setup-go satisfies it from whatever patch the runner image happens to cache, so it silently pinned to a stale toolchain that later went vulnerable. Worth avoiding in either direction.

**The bigger gap is detection, not the pin.** This repo has no `govulncheck` job, which is why the exposure was silent — `basecamp/cli` runs one and is the only repo that noticed. I'd suggest adding govulncheck here on a **schedule** rather than as a PR gate: an advisory published against a toolchain is time-based, not diff-based, so gating PRs on it means unrelated work goes red the moment a CVE drops (which is exactly what just happened to cli #64). A nightly run that reports is the signal; blocking every PR is the tax.

Happy to send that as a follow-up if you want it — deliberately not folded into this bump.
