### PR TITLE
Run govulncheck on a schedule

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,6 +10,12 @@ on:
 
 permissions: {}
 
+# The reporting step reads then writes the tracking issue, which is not atomic.
+# A manual dispatch overlapping the scheduled run could otherwise file two.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   govulncheck:
     name: Govulncheck
@@ -17,6 +23,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      # ./... does not cross module boundaries, so every module is listed.
+      MODULES: "."
+      # Nothing is carried here: this repo has no unfixable findings.
+      ACCEPTED: ""
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -32,8 +43,66 @@ jobs:
       - name: Run govulncheck
         id: scan
         run: |
-          set -o pipefail
-          govulncheck ./... 2>&1 | tee "${RUNNER_TEMP}/govulncheck.txt"
+          set +e
+          : > "${RUNNER_TEMP}/report.txt"
+          rm -f "${RUNNER_TEMP}"/gv-*.json
+          n=0
+          scan_error=0
+          for module in ${MODULES}; do
+            n=$((n + 1))
+            echo "===== ${module}" >> "${RUNNER_TEMP}/report.txt"
+            ( cd "${module}" && govulncheck -format json ./... ) > "${RUNNER_TEMP}/gv-${n}.json" 2> "${RUNNER_TEMP}/gv-${n}.err"
+            rc=$?
+            # govulncheck: 0 = clean, 3 = vulnerabilities found, anything else = it failed to run.
+            if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 3 ]; then
+              scan_error=1
+              echo "govulncheck exited ${rc} (scanner error, not a finding):" >> "${RUNNER_TEMP}/report.txt"
+              cat "${RUNNER_TEMP}/gv-${n}.err" >> "${RUNNER_TEMP}/report.txt"
+              rm -f "${RUNNER_TEMP}/gv-${n}.json"
+              continue
+            fi
+            ( cd "${module}" && govulncheck ./... ) >> "${RUNNER_TEMP}/report.txt" 2>&1
+          done
+          set -e
+
+          cat "${RUNNER_TEMP}/report.txt"
+
+          if [ "${scan_error}" -eq 1 ]; then
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "govulncheck failed to run; see above." >&2
+            exit 1
+          fi
+
+          # Fail only on findings govulncheck considers reachable (a symbol-level trace)
+          # that are not in ACCEPTED -- the same set its "Your code is affected by N
+          # vulnerabilities" line counts.
+          python3 - "$ACCEPTED" > "${RUNNER_TEMP}/new.txt" <<'PY'
+          import glob, json, os, sys
+          accepted = {x for x in sys.argv[1].split() if x}
+          reachable = set()
+          for path in glob.glob(os.environ["RUNNER_TEMP"] + "/gv-*.json"):
+              raw = open(path).read()
+              dec, i = json.JSONDecoder(), 0
+              while i < len(raw):
+                  while i < len(raw) and raw[i].isspace(): i += 1
+                  if i >= len(raw): break
+                  obj, i = dec.raw_decode(raw, i)
+                  f = obj.get("finding")
+                  if f and (f.get("trace") or [{}])[0].get("function"):
+                      reachable.add(f["osv"])
+          new = sorted(reachable - accepted)
+          if new:
+              print("\n".join(new))
+          PY
+
+          if [ -s "${RUNNER_TEMP}/new.txt" ]; then
+            echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
+            echo "New reachable vulnerabilities:"
+            cat "${RUNNER_TEMP}/new.txt"
+            exit 1
+          fi
+          echo "outcome=clean" >> "$GITHUB_OUTPUT"
+          echo "No new reachable vulnerabilities (accepted: ${ACCEPTED:-none})."
 
       - name: Summarize
         if: always()
@@ -42,34 +111,70 @@ jobs:
             echo '## govulncheck'
             echo
             echo '```'
-            cat "${RUNNER_TEMP}/govulncheck.txt"
+            cat "${RUNNER_TEMP}/report.txt" 2>/dev/null || echo '(no output -- the job failed before scanning)'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # A scheduled job that only goes red in the Actions tab is the same silence
-      # this workflow exists to end, so failures open an issue. One at a time:
-      # if a govulncheck issue is already open, the finding is already visible.
+      # Reports any failure, not just a failing scan: a broken checkout or a
+      # failed govulncheck install is also something nobody would otherwise see.
       - name: Report
-        if: failure() && steps.scan.outcome == 'failure'
+        if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTCOME: ${{ steps.scan.outputs.outcome }}
         run: |
-          if [ -n "$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')" ]; then
-            echo "A govulncheck issue is already open; not filing another."
-            exit 0
+          # Always reflect THIS run into the tracking issue. An issue opened for an
+          # earlier advisory says nothing about a new one, so bailing out when any issue
+          # is open would recreate the silence this workflow exists to end. One issue,
+          # kept current, with each run appended.
+          title="govulncheck: findings on the default branch"
+          if [ -s "${RUNNER_TEMP}/report.txt" ]; then
+            body_output=$(cat "${RUNNER_TEMP}/report.txt")
+          else
+            body_output="(govulncheck produced no output -- the job failed before or during the scan; see the run log.)"
           fi
-          gh label create govulncheck --description "Reported by the scheduled govulncheck run" --color d93f0b --force
+
+          if [ "${OUTCOME}" = "error" ]; then
+            headline="The scheduled \`govulncheck\` run **could not complete**. This is a scanner or environment failure, not a vulnerability report."
+          elif [ "${OUTCOME}" = "vulnerable" ]; then
+            headline="The scheduled \`govulncheck\` run found vulnerabilities that are not in this workflow's accepted list."
+          else
+            headline="The scheduled \`govulncheck\` job failed before it could scan. This is an environment or setup failure, not a vulnerability report."
+          fi
+
           {
-            echo "The scheduled \`govulncheck\` run reported vulnerabilities."
+            echo "${headline}"
             echo
             echo "Run: ${RUN_URL}"
+            if [ -s "${RUNNER_TEMP}/new.txt" ]; then
+              echo
+              echo '### Not in the accepted list'
+              echo '```'
+              cat "${RUNNER_TEMP}/new.txt"
+              echo '```'
+            fi
+            echo
+            echo '<details><summary>govulncheck output</summary>'
             echo
             echo '```'
-            cat "${RUNNER_TEMP}/govulncheck.txt"
+            echo "${body_output}"
             echo '```'
             echo
-            echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` to the version named under \"Fixed in\"."
-          } > "${RUNNER_TEMP}/issue.md"
-          gh issue create --title "govulncheck: vulnerabilities reported" --label govulncheck --body-file "${RUNNER_TEMP}/issue.md"
+            echo '</details>'
+            echo
+            echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` (and any \`FROM golang:\` base image) to the version named under \"Fixed in\"."
+          } > "${RUNNER_TEMP}/body.md"
+
+          # Let a failure of the lookup itself stop the job rather than read as "no issue
+          # open", which would file a duplicate.
+          existing=$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')
+
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"
+            echo "Updated issue #${existing}."
+          else
+            gh label create govulncheck --description "Reported by the scheduled govulncheck run" --color d93f0b --force
+            gh issue create --title "${title}" --label govulncheck --body-file "${RUNNER_TEMP}/body.md"
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,9 @@ jobs:
     env:
       # ./... does not cross module boundaries, so every module is listed.
       MODULES: "."
+      # govulncheck's source mode only analyses the files the current build
+      # configuration selects, so scan each GOOS/GOARCH we actually release.
+      TARGETS: "linux/amd64"
       # Nothing is carried here: this repo has no unfixable findings.
       ACCEPTED: ""
     steps:
@@ -48,20 +51,29 @@ jobs:
           rm -f "${RUNNER_TEMP}"/gv-*.json
           n=0
           scan_error=0
-          for module in ${MODULES}; do
-            n=$((n + 1))
-            echo "===== ${module}" >> "${RUNNER_TEMP}/report.txt"
-            ( cd "${module}" && govulncheck -format json ./... ) > "${RUNNER_TEMP}/gv-${n}.json" 2> "${RUNNER_TEMP}/gv-${n}.err"
-            rc=$?
-            # govulncheck: 0 = clean, 3 = vulnerabilities found, anything else = it failed to run.
-            if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 3 ]; then
-              scan_error=1
-              echo "govulncheck exited ${rc} (scanner error, not a finding):" >> "${RUNNER_TEMP}/report.txt"
-              cat "${RUNNER_TEMP}/gv-${n}.err" >> "${RUNNER_TEMP}/report.txt"
-              rm -f "${RUNNER_TEMP}/gv-${n}.json"
-              continue
-            fi
-            ( cd "${module}" && govulncheck ./... ) >> "${RUNNER_TEMP}/report.txt" 2>&1
+          # Releases are built CGO_ENABLED=0 for each GOOS/GOARCH in TARGETS. govulncheck's
+          # source mode only sees the files the current build configuration selects, so a
+          # single native run would miss a path reachable only on another target.
+          export CGO_ENABLED=0
+          for target in ${TARGETS}; do
+            GOOS="${target%%/*}"
+            GOARCH="${target##*/}"
+            export GOOS GOARCH
+            for module in ${MODULES}; do
+              n=$((n + 1))
+              echo "===== ${target} ${module}" >> "${RUNNER_TEMP}/report.txt"
+              ( cd "${module}" && govulncheck -format json ./... ) > "${RUNNER_TEMP}/gv-${n}.json" 2> "${RUNNER_TEMP}/gv-${n}.err"
+              rc=$?
+              # govulncheck: 0 = clean, 3 = vulnerabilities found, anything else = it failed to run.
+              if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 3 ]; then
+                scan_error=1
+                echo "govulncheck exited ${rc} (scanner error, not a finding):" >> "${RUNNER_TEMP}/report.txt"
+                cat "${RUNNER_TEMP}/gv-${n}.err" >> "${RUNNER_TEMP}/report.txt"
+                rm -f "${RUNNER_TEMP}/gv-${n}.json"
+                continue
+              fi
+              ( cd "${module}" && govulncheck ./... ) >> "${RUNNER_TEMP}/report.txt" 2>&1
+            done
           done
           set -e
 
@@ -73,13 +85,17 @@ jobs:
             exit 1
           fi
 
-          # Fail only on findings govulncheck considers reachable (a symbol-level trace)
-          # that are not in ACCEPTED -- the same set its "Your code is affected by N
-          # vulnerabilities" line counts.
+          # Fail on findings govulncheck considers reachable (a symbol-level trace) that
+          # are not in ACCEPTED -- the same set its "Your code is affected by N
+          # vulnerabilities" line counts -- and on accepted IDs that have since gained a
+          # fix for the module path we actually depend on.
           python3 - "$ACCEPTED" > "${RUNNER_TEMP}/new.txt" <<'PY'
           import glob, json, os, sys
+
           accepted = {x for x in sys.argv[1].split() if x}
-          reachable = set()
+          reachable = {}   # osv id -> set of module paths it was reached through
+          advisories = {}
+
           for path in glob.glob(os.environ["RUNNER_TEMP"] + "/gv-*.json"):
               raw = open(path).read()
               dec, i = json.JSONDecoder(), 0
@@ -87,22 +103,49 @@ jobs:
                   while i < len(raw) and raw[i].isspace(): i += 1
                   if i >= len(raw): break
                   obj, i = dec.raw_decode(raw, i)
+                  if "osv" in obj:
+                      advisories[obj["osv"]["id"]] = obj["osv"]
                   f = obj.get("finding")
-                  if f and (f.get("trace") or [{}])[0].get("function"):
-                      reachable.add(f["osv"])
-          new = sorted(reachable - accepted)
-          if new:
-              print("\n".join(new))
+                  if f:
+                      frame = (f.get("trace") or [{}])[0]
+                      if frame.get("function"):
+                          reachable.setdefault(f["osv"], set()).add(frame.get("module"))
+
+          def fixed_versions(osv_id, modules):
+              # Only a fix on a module path we actually import counts. These advisories
+              # routinely list a renamed module (moby/moby/v2) that carries the fix while
+              # the path we depend on (docker/docker) never gets one.
+              out = []
+              for affected in (advisories.get(osv_id) or {}).get("affected", []):
+                  if affected.get("package", {}).get("name") not in modules:
+                      continue
+                  for rng in affected.get("ranges", []):
+                      for event in rng.get("events", []):
+                          if event.get("fixed"):
+                              out.append(f"{affected['package']['name']}@{event['fixed']}")
+              return out
+
+          problems = []
+          for osv_id in sorted(reachable):
+              if osv_id not in accepted:
+                  problems.append(osv_id)
+                  continue
+              fixes = fixed_versions(osv_id, reachable[osv_id])
+              if fixes:
+                  problems.append(f"{osv_id} (accepted, but now fixed in {', '.join(sorted(set(fixes)))} -- drop it from ACCEPTED and upgrade)")
+
+          if problems:
+              print("\n".join(problems))
           PY
 
           if [ -s "${RUNNER_TEMP}/new.txt" ]; then
             echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
-            echo "New reachable vulnerabilities:"
+            echo "Actionable findings:"
             cat "${RUNNER_TEMP}/new.txt"
             exit 1
           fi
           echo "outcome=clean" >> "$GITHUB_OUTPUT"
-          echo "No new reachable vulnerabilities (accepted: ${ACCEPTED:-none})."
+          echo "No actionable findings (accepted: ${ACCEPTED:-none})."
 
       - name: Summarize
         if: always()
@@ -124,12 +167,22 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           OUTCOME: ${{ steps.scan.outputs.outcome }}
+          SCANNED_REF: ${{ github.ref_name }}
+          SCANNED_SHA: ${{ github.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # Always reflect THIS run into the tracking issue. An issue opened for an
           # earlier advisory says nothing about a new one, so bailing out when any issue
           # is open would recreate the silence this workflow exists to end. One issue,
           # kept current, with each run appended.
-          title="govulncheck: findings on the default branch"
+          # A workflow_dispatch can target any ref, so never describe a run as being the
+          # default branch without checking. Non-default refs get their own issue rather
+          # than appending a branch-only finding to the canonical one.
+          if [ "${SCANNED_REF}" = "${DEFAULT_BRANCH}" ]; then
+            title="govulncheck: findings on ${DEFAULT_BRANCH}"
+          else
+            title="govulncheck: findings on ${SCANNED_REF}"
+          fi
           if [ -s "${RUNNER_TEMP}/report.txt" ]; then
             body_output=$(cat "${RUNNER_TEMP}/report.txt")
           else
@@ -147,6 +200,8 @@ jobs:
           {
             echo "${headline}"
             echo
+            echo "Ref: \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\`"
+            echo "Targets: \`${TARGETS}\`"
             echo "Run: ${RUN_URL}"
             if [ -s "${RUNNER_TEMP}/new.txt" ]; then
               echo
@@ -165,11 +220,14 @@ jobs:
             echo '</details>'
             echo
             echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` (and any \`FROM golang:\` base image) to the version named under \"Fixed in\"."
+            echo
+            echo "An entry marked \"accepted, but now fixed\" means an ID in this workflow's ACCEPTED list has gained a fix for a module path we import: upgrade and drop the ID, rather than re-accepting it."
           } > "${RUNNER_TEMP}/body.md"
 
           # Let a failure of the lookup itself stop the job rather than read as "no issue
           # open", which would file a duplicate.
-          existing=$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')
+          existing=$(gh issue list --label govulncheck --state open --limit 30 --json number,title \
+            --jq "[.[] | select(.title == \"${title}\")] | .[0].number // empty")
 
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
       MODULES: "."
       # govulncheck's source mode only analyses the files the current build
       # configuration selects, so scan each GOOS/GOARCH we actually release.
-      TARGETS: "linux/amd64"
+      TARGETS: "linux/amd64 linux/arm64"
       # Nothing is carried here: this repo has no unfixable findings.
       ACCEPTED: ""
     steps:
@@ -93,7 +93,7 @@ jobs:
           import glob, json, os, sys
 
           accepted = {x for x in sys.argv[1].split() if x}
-          reachable = {}   # osv id -> set of module paths it was reached through
+          reachable = {}   # osv id -> {module path: set of versions} it was reached through
           advisories = {}
 
           for path in glob.glob(os.environ["RUNNER_TEMP"] + "/gv-*.json"):
@@ -109,20 +109,53 @@ jobs:
                   if f:
                       frame = (f.get("trace") or [{}])[0]
                       if frame.get("function"):
-                          reachable.setdefault(f["osv"], set()).add(frame.get("module"))
+                          mods = reachable.setdefault(f["osv"], {})
+                          mods.setdefault(frame.get("module"), set()).add(frame.get("version") or "v0.0.0")
 
-          def fixed_versions(osv_id, modules):
-              # Only a fix on a module path we actually import counts. These advisories
-              # routinely list a renamed module (moby/moby/v2) that carries the fix while
-              # the path we depend on (docker/docker) never gets one.
+          def parse(version):
+              # Enough of semver to order Go module versions: drop the leading v and any
+              # +incompatible/build metadata, split off a prerelease, compare numerically.
+              version = version.lstrip("v").split("+", 1)[0]
+              main, _, pre = version.partition("-")
+              parts = []
+              for chunk in main.split("."):
+                  parts.append(int(chunk) if chunk.isdigit() else 0)
+              while len(parts) < 3:
+                  parts.append(0)
+              # No prerelease sorts above a prerelease of the same version.
+              return (parts, 0 if pre else 1, pre)
+
+          def fix_for(osv_id, module_versions):
+              # Only a fix on a module path we actually import counts: these advisories
+              # routinely list a renamed module (moby/moby/v2) carrying the fix while the
+              # path we depend on (docker/docker) never gets one.
+              #
+              # And only a fix for the interval OUR version falls in counts. An advisory
+              # can be fixed, then reintroduced and left unfixed; treating the historical
+              # fixed event as an upgrade would fail the job forever with advice that does
+              # not apply.
               out = []
               for affected in (advisories.get(osv_id) or {}).get("affected", []):
-                  if affected.get("package", {}).get("name") not in modules:
+                  name = affected.get("package", {}).get("name")
+                  if name not in module_versions:
                       continue
-                  for rng in affected.get("ranges", []):
-                      for event in rng.get("events", []):
-                          if event.get("fixed"):
-                              out.append(f"{affected['package']['name']}@{event['fixed']}")
+                  for ours in module_versions[name]:
+                      try:
+                          target = parse(ours)
+                      except Exception:
+                          continue
+                      for rng in affected.get("ranges", []):
+                          introduced, fixed = None, None
+                          for event in rng.get("events", []):
+                              if event.get("introduced") is not None:
+                                  # A new interval starts; the previous one did not contain us.
+                                  introduced, fixed = event["introduced"], None
+                              elif event.get("fixed") is not None:
+                                  fixed = event["fixed"]
+                                  if introduced is not None and parse(introduced) <= target < parse(fixed):
+                                      out.append(f"{name}@{fixed}")
+                                  introduced = None
+                          # A trailing introduced with no fixed is an open, unfixed interval.
               return out
 
           problems = []
@@ -130,7 +163,7 @@ jobs:
               if osv_id not in accepted:
                   problems.append(osv_id)
                   continue
-              fixes = fixed_versions(osv_id, reachable[osv_id])
+              fixes = fix_for(osv_id, reachable[osv_id])
               if fixes:
                   problems.append(f"{osv_id} (accepted, but now fixed in {', '.join(sorted(set(fixes)))} -- drop it from ACCEPTED and upgrade)")
 
@@ -226,8 +259,13 @@ jobs:
 
           # Let a failure of the lookup itself stop the job rather than read as "no issue
           # open", which would file a duplicate.
-          existing=$(gh issue list --label govulncheck --state open --limit 30 --json number,title \
-            --jq "[.[] | select(.title == \"${title}\")] | .[0].number // empty")
+          # The title carries a ref name, which git allows to contain quotes -- pass it to
+          # jq as data via $ENV rather than interpolating it into the jq program.
+          # $ENV.TITLE is expanded by jq, not by the shell -- that is the point of passing
+          # the title as data instead of interpolating it, so SC2016 is expected here.
+          # shellcheck disable=SC2016
+          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 30 --json number,title \
+            --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty')
 
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -240,19 +240,30 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Reports any failure, not just a failing scan: a broken checkout or a
-      # failed govulncheck install is also something nobody would otherwise see.
+      # Runs on success too, not just failure: a failing run leaves an issue open,
+      # and only a later clean run can close it. Skipped only on cancellation.
       - name: Report
-        if: failure()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           OUTCOME: ${{ steps.scan.outputs.outcome }}
+          TARGETS: "linux/amd64 linux/arm64"
           SCANNED_REF: ${{ github.ref_name }}
           SCANNED_SHA: ${{ github.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          # --limit bounds how many issues are fetched, and the jq filter only sees those.
+          # Failed dispatches on different refs deliberately open separate issues, so a
+          # small page could miss this ref's issue and open a duplicate. The label already
+          # narrows this to our own issues; the limit is just a sane ceiling above it.
+          lookup() {
+            # shellcheck disable=SC2016
+            TITLE="$1" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
+              --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty'
+          }
+
           # Always reflect THIS run into the tracking issue. An issue opened for an
           # earlier advisory says nothing about a new one, so bailing out when any issue
           # is open would recreate the silence this workflow exists to end. One issue,
@@ -265,6 +276,26 @@ jobs:
           else
             title="govulncheck: findings on ${SCANNED_REF}"
           fi
+          existing=$(lookup "${title}")
+
+          # A clean run has to close the loop as well. Otherwise the issue from a run that
+          # failed -- or from a vulnerability since fixed -- stays open forever and the
+          # tracking state is stale in the other direction.
+          if [ "${OUTCOME}" = "clean" ]; then
+            if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again on \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
+
+          Run: ${RUN_URL}
+
+          Closing; a later failure reopens tracking by filing a fresh issue."
+              gh issue close "${existing}" --reason completed
+              echo "Closed issue #${existing} -- scan is clean."
+            else
+              echo "Scan is clean and no tracking issue is open; nothing to do."
+            fi
+            exit 0
+          fi
+
           if [ -s "${RUNNER_TEMP}/report.txt" ]; then
             body_output=$(cat "${RUNNER_TEMP}/report.txt")
           else
@@ -315,13 +346,6 @@ jobs:
           # $ENV.TITLE is expanded by jq, not by the shell -- that is the point of passing
           # the title as data instead of interpolating it, so SC2016 is expected here.
           # shellcheck disable=SC2016
-          # --limit bounds how many issues are fetched, and the jq filter only sees those.
-          # Failed dispatches on different refs deliberately open separate issues, so a
-          # small page could miss this ref's issue and open a duplicate. The label already
-          # narrows this to our own issues; the limit is just a sane ceiling above it.
-          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
-            --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty')
-
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"
             echo "Updated issue #${existing}."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,17 +110,36 @@ jobs:
                           mods.setdefault(frame.get("module"), set()).add(frame.get("version") or "v0.0.0")
 
           def parse(version):
-              # Enough of semver to order Go module versions: drop the leading v and any
-              # +incompatible/build metadata, split off a prerelease, compare numerically.
-              version = version.lstrip("v").split("+", 1)[0]
+              # Order Go module versions by SemVer rules. Two prefixes to shed: module
+              # versions carry "v" (v28.5.2), and stdlib findings carry "go" (go1.26.5)
+              # while the advisory's own ranges use a bare 1.26.5 -- comparing those
+              # unnormalized would match the wrong interval entirely. Build metadata
+              # (+incompatible) does not participate in precedence.
+              version = version.split("+", 1)[0]
+              if version.startswith("go"):
+                  version = version[2:]
+              elif version.startswith("v"):
+                  version = version[1:]
               main, _, pre = version.partition("-")
-              parts = []
+
+              release = []
               for chunk in main.split("."):
-                  parts.append(int(chunk) if chunk.isdigit() else 0)
-              while len(parts) < 3:
-                  parts.append(0)
-              # No prerelease sorts above a prerelease of the same version.
-              return (parts, 0 if pre else 1, pre)
+                  release.append(int(chunk) if chunk.isdigit() else 0)
+              while len(release) < 3:
+                  release.append(0)
+
+              # SemVer 11.4: dot-separated prerelease identifiers compare field by field;
+              # numeric ones compare numerically and rank below alphanumeric ones. String
+              # comparison would put beta.10 before beta.2.
+              identifiers = []
+              for chunk in pre.split(".") if pre else []:
+                  if chunk.isdigit():
+                      identifiers.append((0, int(chunk), ""))
+                  else:
+                      identifiers.append((1, 0, chunk))
+
+              # A version with no prerelease outranks the same release with one.
+              return (release, 0 if pre else 1, identifiers)
 
           def fix_for(osv_id, module_versions):
               # Only a fix on a module path we actually import counts: these advisories
@@ -154,6 +173,14 @@ jobs:
                                   introduced = None
                           # A trailing introduced with no fixed is an open, unfixed interval.
               return out
+
+          # An accepted ID that no longer shows up is a suppression with nothing left to
+          # suppress -- dead config that would silently swallow the advisory if a future
+          # version reintroduced it. Worth saying, not worth failing a clean run over.
+          stale = sorted(accepted - set(reachable))
+          if stale:
+              with open(os.environ["RUNNER_TEMP"] + "/stale-accepted.txt", "w") as handle:
+                  handle.write("\n".join(stale) + "\n")
 
           problems = []
           for osv_id in sorted(reachable):
@@ -196,6 +223,18 @@ jobs:
           {
             echo '## govulncheck'
             echo
+            if [ -s "${RUNNER_TEMP}/stale-accepted.txt" ]; then
+              echo '### Accepted IDs no longer reported'
+              echo
+              echo 'These are in ACCEPTED but the scan no longer finds them -- most likely'
+              echo 'the dependency was upgraded. Drop them, so the list cannot silently'
+              echo 'swallow the advisory if a later version reintroduces it.'
+              echo
+              echo '```'
+              cat "${RUNNER_TEMP}/stale-accepted.txt"
+              echo '```'
+              echo
+            fi
             echo '```'
             cat "${RUNNER_TEMP}/report.txt" 2>/dev/null || echo '(no output -- the job failed before scanning)'
             echo '```'
@@ -276,7 +315,11 @@ jobs:
           # $ENV.TITLE is expanded by jq, not by the shell -- that is the point of passing
           # the title as data instead of interpolating it, so SC2016 is expected here.
           # shellcheck disable=SC2016
-          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 30 --json number,title \
+          # --limit bounds how many issues are fetched, and the jq filter only sees those.
+          # Failed dispatches on different refs deliberately open separate issues, so a
+          # small page could miss this ref's issue and open a duplicate. The label already
+          # narrows this to our own issues; the limit is just a sane ceiling above it.
+          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
             --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty')
 
           if [ -n "${existing}" ]; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -79,11 +79,8 @@ jobs:
 
           cat "${RUNNER_TEMP}/report.txt"
 
-          if [ "${scan_error}" -eq 1 ]; then
-            echo "outcome=error" >> "$GITHUB_OUTPUT"
-            echo "govulncheck failed to run; see above." >&2
-            exit 1
-          fi
+          # A failed target must not bury a real finding from a target that succeeded, so
+          # always filter whatever JSON was produced before deciding what to report.
 
           # Fail on findings govulncheck considers reachable (a symbol-level trace) that
           # are not in ACCEPTED -- the same set its "Your code is affected by N
@@ -171,10 +168,23 @@ jobs:
               print("\n".join(problems))
           PY
 
+          findings=0
           if [ -s "${RUNNER_TEMP}/new.txt" ]; then
-            echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
+            findings=1
             echo "Actionable findings:"
             cat "${RUNNER_TEMP}/new.txt"
+          fi
+
+          if [ "${scan_error}" -eq 1 ] && [ "${findings}" -eq 1 ]; then
+            echo "outcome=vulnerable-and-error" >> "$GITHUB_OUTPUT"
+            echo "govulncheck also failed to run for at least one target/module; see above." >&2
+            exit 1
+          elif [ "${scan_error}" -eq 1 ]; then
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "govulncheck failed to run for at least one target/module; see above." >&2
+            exit 1
+          elif [ "${findings}" -eq 1 ]; then
+            echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           echo "outcome=clean" >> "$GITHUB_OUTPUT"
@@ -222,7 +232,9 @@ jobs:
             body_output="(govulncheck produced no output -- the job failed before or during the scan; see the run log.)"
           fi
 
-          if [ "${OUTCOME}" = "error" ]; then
+          if [ "${OUTCOME}" = "vulnerable-and-error" ]; then
+            headline="The scheduled \`govulncheck\` run found vulnerabilities that are not in this workflow's accepted list, **and** failed to scan at least one target or module. Both need attention: the findings below are real, and the coverage gap means there may be more."
+          elif [ "${OUTCOME}" = "error" ]; then
             headline="The scheduled \`govulncheck\` run **could not complete**. This is a scanner or environment failure, not a vulnerability report."
           elif [ "${OUTCOME}" = "vulnerable" ]; then
             headline="The scheduled \`govulncheck\` run found vulnerabilities that are not in this workflow's accepted list."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,75 @@
+name: Security
+
+# Toolchain and dependency advisories are published against code that has not
+# changed, so this runs on a clock rather than on a diff. Gating pull requests
+# on it would turn every newly published CVE into a red build on unrelated work.
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        id: scan
+        run: |
+          set -o pipefail
+          govulncheck ./... 2>&1 | tee "${RUNNER_TEMP}/govulncheck.txt"
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo '## govulncheck'
+            echo
+            echo '```'
+            cat "${RUNNER_TEMP}/govulncheck.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A scheduled job that only goes red in the Actions tab is the same silence
+      # this workflow exists to end, so failures open an issue. One at a time:
+      # if a govulncheck issue is already open, the finding is already visible.
+      - name: Report
+        if: failure() && steps.scan.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -n "$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')" ]; then
+            echo "A govulncheck issue is already open; not filing another."
+            exit 0
+          fi
+          gh label create govulncheck --description "Reported by the scheduled govulncheck run" --color d93f0b --force
+          {
+            echo "The scheduled \`govulncheck\` run reported vulnerabilities."
+            echo
+            echo "Run: ${RUN_URL}"
+            echo
+            echo '```'
+            cat "${RUNNER_TEMP}/govulncheck.txt"
+            echo '```'
+            echo
+            echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` to the version named under \"Fixed in\"."
+          } > "${RUNNER_TEMP}/issue.md"
+          gh issue create --title "govulncheck: vulnerabilities reported" --label govulncheck --body-file "${RUNNER_TEMP}/issue.md"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,9 +11,11 @@ on:
 permissions: {}
 
 # The reporting step reads then writes the tracking issue, which is not atomic.
-# A manual dispatch overlapping the scheduled run could otherwise file two.
+# Keyed by ref because that is the unit of contention: each ref has its own
+# tracking issue, so runs on different refs never touch the same one, and only
+# same-ref runs -- which scan the same tree -- need to queue behind each other.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -251,6 +253,9 @@ jobs:
           OUTCOME: ${{ steps.scan.outputs.outcome }}
           TARGETS: "linux/amd64 linux/arm64"
           SCANNED_REF: ${{ github.ref_name }}
+          # A branch and a tag can share a short name; the full ref keeps their
+          # tracking issues apart.
+          SCANNED_FULL_REF: ${{ github.ref }}
           SCANNED_SHA: ${{ github.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
@@ -271,10 +276,14 @@ jobs:
           # A workflow_dispatch can target any ref, so never describe a run as being the
           # default branch without checking. Non-default refs get their own issue rather
           # than appending a branch-only finding to the canonical one.
-          if [ "${SCANNED_REF}" = "${DEFAULT_BRANCH}" ]; then
+          case "${SCANNED_FULL_REF}" in
+            refs/tags/*) ref_label="tag ${SCANNED_REF}" ;;
+            *)           ref_label="${SCANNED_REF}" ;;
+          esac
+          if [ "${SCANNED_FULL_REF}" = "refs/heads/${DEFAULT_BRANCH}" ]; then
             title="govulncheck: findings on ${DEFAULT_BRANCH}"
           else
-            title="govulncheck: findings on ${SCANNED_REF}"
+            title="govulncheck: findings on ${ref_label}"
           fi
           existing=$(lookup "${title}")
 
@@ -283,7 +292,7 @@ jobs:
           # tracking state is stale in the other direction.
           if [ "${OUTCOME}" = "clean" ]; then
             if [ -n "${existing}" ]; then
-              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again on \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
+              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again on \`${SCANNED_FULL_REF}\` @ \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
 
           Run: ${RUN_URL}
 
@@ -296,10 +305,21 @@ jobs:
             exit 0
           fi
 
-          if [ -s "${RUNNER_TEMP}/report.txt" ]; then
-            body_output=$(cat "${RUNNER_TEMP}/report.txt")
-          else
+          # GitHub caps an issue body or comment at 65536 characters. A dozen scans of
+          # verbose output can pass that, and gh would fail the whole report -- turning a
+          # large finding into no notification at all, which is the failure this workflow
+          # exists to prevent. Keep the head and tail and say what was dropped.
+          limit=45000
+          if [ ! -s "${RUNNER_TEMP}/report.txt" ]; then
             body_output="(govulncheck produced no output -- the job failed before or during the scan; see the run log.)"
+          elif [ "$(wc -c < "${RUNNER_TEMP}/report.txt")" -gt "${limit}" ]; then
+            body_output="$(head -c 22000 "${RUNNER_TEMP}/report.txt")
+
+          [... truncated to fit GitHub's 65536-character limit -- full output in the run log ...]
+
+          $(tail -c 22000 "${RUNNER_TEMP}/report.txt")"
+          else
+            body_output=$(cat "${RUNNER_TEMP}/report.txt")
           fi
 
           if [ "${OUTCOME}" = "vulnerable-and-error" ]; then
@@ -315,7 +335,7 @@ jobs:
           {
             echo "${headline}"
             echo
-            echo "Ref: \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\`"
+            echo "Ref: \`${SCANNED_FULL_REF}\` @ \`${SCANNED_SHA}\`"
             echo "Targets: \`${TARGETS}\`"
             echo "Run: ${RUN_URL}"
             if [ -s "${RUNNER_TEMP}/new.txt" ]; then


### PR DESCRIPTION
This repo had no vulnerability scanning at all. That's how six Go standard library advisories sat against it unnoticed — I only found them because `basecamp/cli` runs govulncheck, went red, and prompted a check of the other Go repos. Nothing reported them here because nothing was looking.

**Merge #234 first** (the go1.26.7 bump). This job would fail on today's `main` — correctly, since `main` is still on the vulnerable toolchain.

Plain `govulncheck ./...`: after #234 this repo has no findings, so there is nothing to allow-list and no filtering machinery to justify. `once` and `basecamp-installer` carry two docker advisories with no available fix, so their copies of this workflow have an explicit accepted-IDs list. Same pattern, complexity only where it's earned.

### Why scheduled and not a PR gate

A toolchain or dependency advisory is published against code that has not changed. Gating pull requests on it means the next CVE turns unrelated work red — which is precisely what happened to `basecamp/cli` today: its govulncheck job passed at 09:24 and, on the identical commit, failed an hour later. The clock is the right trigger; the diff isn't.

Runs daily, plus `workflow_dispatch` for on-demand. Times are staggered across the three repos.

### Why it opens an issue

A scheduled job that only goes red in the Actions tab is the same silence this exists to end — GitHub's failure notifications for cron workflows go to whoever last touched the schedule, which isn't a team signal. So a failing run files one issue, labelled `govulncheck`, with the run URL and the full output. It files **one at a time**: if a `govulncheck` issue is already open, the finding is already visible and it won't pile on.

Permissions are `contents: read` + `issues: write`, scoped to the job, under a top-level `permissions: {}`. Schedules only run on the default branch, so no untrusted PR code reaches that token.

### Verification

`actionlint` 1.7.12 and `zizmor` 1.29.0 (default persona, online) both report clean on the new file.
