### PR TITLE
Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install golangci-lint
       uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
       with:
-        version: v2.11.3
+        version: v2.13.1
 
     - name: Install dependencies
       run: go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.7 AS build
+FROM golang:1.27.0 AS build
 
 WORKDIR /app
 

--- a/example/upstream/Dockerfile
+++ b/example/upstream/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.26.7 as build
+from golang:1.27.0 as build
 workdir /app
 copy . .
 env CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/kamal-proxy
 
-go 1.26.7
+go 1.27.0
 
 require (
 	github.com/coder/websocket v1.8.12

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.27.0
 
 require (
 	github.com/coder/websocket v1.8.12
-	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/quic-go/quic-go v0.60.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/internal/server/request_id_middleware.go
+++ b/internal/server/request_id_middleware.go
@@ -2,8 +2,7 @@ package server
 
 import (
 	"net/http"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 const (


### PR DESCRIPTION
- Build with Go 1.27
- Ditch the `google/uuid` dependency, since we now have `uuid` in the stdlib