### PR TITLE
Add `check` target to `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test bench docker
+.PHONY: build test lint check bench docker
 
 build:
 	CGO_ENABLED=0 go build -trimpath -o bin/ ./cmd/...
@@ -8,6 +8,11 @@ test:
 
 lint:
 	golangci-lint run
+	go fix -diff ./...
+
+check:
+	go vet ./...
+	govulncheck ./...
 
 bench:
 	go test -bench=. -benchmem -run=^# ./...

--- a/internal/server/target.go
+++ b/internal/server/target.go
@@ -395,8 +395,7 @@ func (t *Target) isRequestEntityTooLarge(err error) bool {
 }
 
 func (t *Target) isGatewayTimeout(err error) bool {
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
 		return netErr.Timeout()
 	}
 	return false


### PR DESCRIPTION
Now:
- `lint` spots formatting/style
- `check` spots problems 

Also included one modernisation spotted by the new lint check.