### PR TITLE
Fix rollout percentage boundaries

### DIFF
--- a/internal/server/rollout_controller.go
+++ b/internal/server/rollout_controller.go
@@ -15,8 +15,7 @@ type RolloutController struct {
 }
 
 func NewRolloutController(percentage int, allowlist []string) *RolloutController {
-	maxHashValue := float64(uint32(0xFFFFFFFF))
-	percentageSplitPoint := maxHashValue * (float64(percentage) / 100.0)
+	percentageSplitPoint := float64(1<<32) * float64(percentage) / 100.0
 
 	return &RolloutController{
 		Percentage:           percentage,
@@ -44,7 +43,7 @@ func (rc *RolloutController) valueInAllowlist(value string) bool {
 
 func (rc *RolloutController) valueInRolloutPercentage(value string) bool {
 	hash := rc.hashForValue(value)
-	return float64(hash) <= rc.PercentageSplitPoint
+	return float64(hash) < rc.PercentageSplitPoint
 }
 
 func (rc *RolloutController) hashForValue(value string) uint32 {


### PR DESCRIPTION
At 0%, a value with hash 0 entered the rollout group. Compare with < and split over the full 2^32 hash range, so 0% admits no values and 100% admits every value.