### PR TITLE
Add `rollout remove` command

### DIFF
--- a/internal/cmd/rollout.go
+++ b/internal/cmd/rollout.go
@@ -16,6 +16,7 @@ func newRolloutCommand() *rolloutCommand {
 	rolloutCommand.cmd.AddCommand(newRolloutDeployCommand().cmd)
 	rolloutCommand.cmd.AddCommand(newRolloutSetCommand().cmd)
 	rolloutCommand.cmd.AddCommand(newRolloutStopCommand().cmd)
+	rolloutCommand.cmd.AddCommand(newRolloutRemoveCommand().cmd)
 
 	return rolloutCommand
 }

--- a/internal/cmd/rollout_deploy.go
+++ b/internal/cmd/rollout_deploy.go
@@ -16,7 +16,7 @@ func newRolloutDeployCommand() *rolloutDeployCommand {
 	rolloutDeployCommand := &rolloutDeployCommand{}
 	rolloutDeployCommand.cmd = &cobra.Command{
 		Use:       "deploy <service>",
-		Short:     "Deploy the rollout target",
+		Short:     "Deploy the rollout target(s)",
 		RunE:      rolloutDeployCommand.run,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{"service"},

--- a/internal/cmd/rollout_remove.go
+++ b/internal/cmd/rollout_remove.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"net/rpc"
+
+	"github.com/basecamp/kamal-proxy/internal/server"
+	"github.com/spf13/cobra"
+)
+
+type rolloutRemoveCommand struct {
+	cmd  *cobra.Command
+	args server.RolloutRemoveArgs
+}
+
+func newRolloutRemoveCommand() *rolloutRemoveCommand {
+	rolloutRemoveCommand := &rolloutRemoveCommand{}
+	rolloutRemoveCommand.cmd = &cobra.Command{
+		Use:       "remove <service>",
+		Short:     "Remove the rollout target(s)",
+		RunE:      rolloutRemoveCommand.run,
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"service"},
+	}
+
+	rolloutRemoveCommand.cmd.Flags().DurationVar(&rolloutRemoveCommand.args.DrainTimeout, "drain-timeout", server.DefaultDrainTimeout, "Maximum time to allow existing connections to drain before removing the rollout targets")
+
+	return rolloutRemoveCommand
+}
+
+func (c *rolloutRemoveCommand) run(cmd *cobra.Command, args []string) error {
+	c.args.Service = args[0]
+
+	return withRPCClient(globalConfig.SocketPath(), func(client *rpc.Client) error {
+		var response bool
+		return client.Call("kamal-proxy.RolloutRemove", c.args, &response)
+	})
+}

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -62,6 +62,11 @@ type RolloutStopArgs struct {
 	Service string
 }
 
+type RolloutRemoveArgs struct {
+	Service      string
+	DrainTimeout time.Duration
+}
+
 type ListResponse struct {
 	Targets ServiceDescriptionMap `json:"services"`
 }
@@ -148,4 +153,8 @@ func (h *CommandHandler) RolloutSet(args RolloutSetArgs, reply *bool) error {
 
 func (h *CommandHandler) RolloutStop(args RolloutStopArgs, reply *bool) error {
 	return h.router.StopRollout(args.Service)
+}
+
+func (h *CommandHandler) RolloutRemove(args RolloutRemoveArgs, reply *bool) error {
+	return h.router.RemoveRolloutTargets(args.Service, args.DrainTimeout)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -196,6 +196,25 @@ func (r *Router) StopRollout(name string) error {
 	return service.StopRollout()
 }
 
+func (r *Router) RemoveRolloutTargets(name string, drainTimeout time.Duration) error {
+	service := r.serviceForName(name)
+	if service == nil {
+		return ErrorServiceNotFound
+	}
+
+	removed, err := service.RemoveRollout()
+	if err != nil {
+		return err
+	}
+
+	_ = r.saveStateSnapshot()
+
+	removed.Dispose()
+	removed.DrainAll(drainTimeout)
+
+	return nil
+}
+
 func (r *Router) RemoveService(name string) error {
 	defer r.saveStateSnapshot()
 

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -760,6 +760,34 @@ func TestRouter_EnablingRollout(t *testing.T) {
 	checkResponse("first")
 }
 
+func TestRouter_RemovingRollout(t *testing.T) {
+	router := testRouter(t)
+	_, first := testBackend(t, "first", http.StatusOK)
+	_, second := testBackend(t, "second", http.StatusOK)
+
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
+	assert.Equal(t, ErrorRolloutTargetNotSet, router.RemoveRolloutTargets("service1", DefaultDrainTimeout))
+	assert.Equal(t, ErrorServiceNotFound, router.RemoveRolloutTargets("service2", DefaultDrainTimeout))
+
+	require.NoError(t, router.SetRolloutTargets("service1", []string{second}, defaultEmptyReaders, defaultDeploymentOptions))
+	require.NoError(t, router.SetRolloutSplit("service1", 0, []string{"1"}))
+
+	checkResponse := func(expected string) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+		req.AddCookie(&http.Cookie{Name: "kamal-rollout", Value: "1"})
+		statusCode, body := sendRequest(router, req)
+		assert.Equal(t, http.StatusOK, statusCode)
+		assert.Equal(t, expected, body)
+	}
+
+	checkResponse("second")
+
+	require.NoError(t, router.RemoveRolloutTargets("service1", DefaultDrainTimeout))
+	checkResponse("first")
+
+	assert.Equal(t, ErrorRolloutTargetNotSet, router.SetRolloutSplit("service1", 0, []string{"1"}))
+}
+
 func TestRouter_RestoreLastSavedState(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -271,6 +271,21 @@ func (s *Service) StopRollout() error {
 	return nil
 }
 
+func (s *Service) RemoveRollout() (*LoadBalancer, error) {
+	s.serviceLock.Lock()
+	defer s.serviceLock.Unlock()
+
+	if s.rollout == nil {
+		return nil, ErrorRolloutTargetNotSet
+	}
+
+	removed := s.rollout
+	s.rollout = nil
+	s.rolloutController = nil
+	slog.Info("Removed rollout targets", "service", s.name)
+	return removed, nil
+}
+
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.options.ShouldExcludeMetrics(r) {
 		LoggingRequestContext(r).ExcludeMetrics = true

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -226,9 +226,11 @@ func (s *Service) UpdateOptions(options ServiceOptions, targetOptions TargetOpti
 }
 
 func (s *Service) Dispose() {
-	s.active.Dispose()
-	if s.rollout != nil {
-		s.rollout.Dispose()
+	active, rollout := s.loadBalancers()
+
+	active.Dispose()
+	if rollout != nil {
+		rollout.Dispose()
 	}
 }
 
@@ -315,23 +317,27 @@ type marshalledService struct {
 }
 
 func (s *Service) MarshalJSON() ([]byte, error) {
+	s.serviceLock.RLock()
+	active, rollout, rolloutController := s.active, s.rollout, s.rolloutController
+	s.serviceLock.RUnlock()
+
 	var rolloutTargets []string
 	var rolloutReaders []string
-	if s.rollout != nil {
-		rolloutTargets = s.rollout.WriteTargets().Names()
-		rolloutReaders = s.rollout.ReadTargets().Names()
+	if rollout != nil {
+		rolloutTargets = rollout.WriteTargets().Names()
+		rolloutReaders = rollout.ReadTargets().Names()
 	}
 
 	return json.Marshal(marshalledService{
 		Name:              s.name,
-		ActiveTargets:     s.active.WriteTargets().Names(),
-		ActiveReaders:     s.active.ReadTargets().Names(),
+		ActiveTargets:     active.WriteTargets().Names(),
+		ActiveReaders:     active.ReadTargets().Names(),
 		RolloutTargets:    rolloutTargets,
 		RolloutReaders:    rolloutReaders,
 		Options:           s.options,
 		TargetOptions:     s.targetOptions,
 		PauseController:   s.pauseController,
-		RolloutController: s.rolloutController,
+		RolloutController: rolloutController,
 	})
 }
 
@@ -438,16 +444,25 @@ func (s *Service) initialize(options ServiceOptions, targetOptions TargetOptions
 }
 
 func (s *Service) Drain(timeout time.Duration) {
+	active, rollout := s.loadBalancers()
+
 	PerformConcurrently(
 		func() {
-			s.active.DrainAll(timeout)
+			active.DrainAll(timeout)
 		},
 		func() {
-			if s.rollout != nil {
-				s.rollout.DrainAll(timeout)
+			if rollout != nil {
+				rollout.DrainAll(timeout)
 			}
 		},
 	)
+}
+
+func (s *Service) loadBalancers() (active, rollout *LoadBalancer) {
+	s.serviceLock.RLock()
+	defer s.serviceLock.RUnlock()
+
+	return s.active, s.rollout
 }
 
 func (s *Service) loadBalancerForRequest(req *http.Request) *LoadBalancer {

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -295,6 +295,27 @@ func TestService_MarshallingState(t *testing.T) {
 	assert.Equal(t, []string{"first"}, service2.rolloutController.Allowlist)
 }
 
+func TestService_MarshallingStateAfterRemovingRollout(t *testing.T) {
+	service := testCreateService(t, defaultServiceOptions, defaultTargetOptions)
+	t.Cleanup(service.Dispose)
+	service.UpdateLoadBalancer(NewLoadBalancer(service.active.Targets(), DefaultWriterAffinityTimeout, false), TargetSlotRollout)
+	require.NoError(t, service.SetRolloutSplit(20, []string{"first"}))
+
+	removed, err := service.RemoveRollout()
+	require.NoError(t, err)
+	removed.Dispose()
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(service))
+
+	var service2 Service
+	require.NoError(t, json.NewDecoder(&buf).Decode(&service2))
+	t.Cleanup(service2.Dispose)
+
+	assert.Nil(t, service2.rollout)
+	assert.Nil(t, service2.rolloutController)
+}
+
 func TestService_UnmarshallingStateFromLegacyFormat(t *testing.T) {
 	state := `
 	  {

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -316,6 +316,30 @@ func TestService_MarshallingStateAfterRemovingRollout(t *testing.T) {
 	assert.Nil(t, service2.rolloutController)
 }
 
+func TestService_RemovingRolloutWhileDrainingAndMarshalling(t *testing.T) {
+	service := testCreateService(t, defaultServiceOptions, defaultTargetOptions)
+	t.Cleanup(service.Dispose)
+
+	for range 50 {
+		targets, err := NewTargetList(nil, nil, defaultTargetOptions)
+		require.NoError(t, err)
+		service.UpdateLoadBalancer(NewLoadBalancer(targets, DefaultWriterAffinityTimeout, false), TargetSlotRollout)
+
+		PerformConcurrently(
+			func() { service.Drain(time.Second) },
+			func() { service.Dispose() },
+			func() { _, _ = json.Marshal(service) },
+			func() {
+				removed, err := service.RemoveRollout()
+				require.NoError(t, err)
+				removed.Dispose()
+			},
+		)
+	}
+
+	assert.Nil(t, service.rollout)
+}
+
 func TestService_UnmarshallingStateFromLegacyFormat(t *testing.T) {
 	state := `
 	  {


### PR DESCRIPTION
Add a new `rollout` subcommand, `rollout remove`, which clears the deployed rollout targets.