### PR TITLE
Use golangci-lint modernize instead of go fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,5 +5,7 @@ formatters:
     - gofmt
 
 linters:
+  enable:
+    - modernize
   disable:
     - errcheck

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ test:
 
 lint:
 	golangci-lint run
-	go fix -diff ./...
 
 check:
 	go vet ./...


### PR DESCRIPTION
The modernize linter runs the same analyzers as go fix, and govet already covers the inline and buildtag checks. One tool now does all the lint work.