### PR TITLE
Rollout reporting

### DIFF
--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
 	"maps"
 	"net/rpc"
 	"slices"
@@ -11,7 +13,8 @@ import (
 )
 
 type listCommand struct {
-	cmd *cobra.Command
+	cmd  *cobra.Command
+	json bool
 }
 
 func newListCommand() *listCommand {
@@ -23,6 +26,8 @@ func newListCommand() *listCommand {
 		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 	}
+
+	listCommand.cmd.Flags().BoolVar(&listCommand.json, "json", false, "Output the list as JSON")
 
 	return listCommand
 }
@@ -36,19 +41,41 @@ func (c *listCommand) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		c.displayResponse(response)
+		if c.json {
+			return c.displayJSON(response)
+		}
+
+		c.displayTable(response)
 		return nil
 	})
 }
 
-func (c *listCommand) displayResponse(response server.ListResponse) {
+func (c *listCommand) displayJSON(response server.ListResponse) error {
+	output, err := json.MarshalIndent(response.Targets, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+	return nil
+}
+
+func (c *listCommand) displayTable(response server.ListResponse) {
 	table := NewTable()
 	table.AddRow([]string{"Service", "Host", "Path", "Target", "State", "TLS", "Rollout"})
 
 	sortedKeys := slices.Sorted(maps.Keys(response.Targets))
 	for _, name := range sortedKeys {
 		service := response.Targets[name]
-		table.AddRow([]string{name, service.Host, service.Path, service.Target, service.State, yesNo(service.TLS), yesNo(service.Rollout)})
+		table.AddRow([]string{
+			name,
+			service.DisplayHosts(),
+			service.DisplayPaths(),
+			service.DisplayTargets(),
+			service.State,
+			yesNo(service.TLS),
+			yesNo(service.Rollout.Enabled),
+		})
 	}
 
 	table.Print()

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -43,18 +43,20 @@ func (c *listCommand) run(cmd *cobra.Command, args []string) error {
 
 func (c *listCommand) displayResponse(response server.ListResponse) {
 	table := NewTable()
-	table.AddRow([]string{"Service", "Host", "Path", "Target", "State", "TLS"})
+	table.AddRow([]string{"Service", "Host", "Path", "Target", "State", "TLS", "Rollout"})
 
 	sortedKeys := slices.Sorted(maps.Keys(response.Targets))
 	for _, name := range sortedKeys {
 		service := response.Targets[name]
-		tls := "no"
-		if service.TLS {
-			tls = "yes"
-		}
-
-		table.AddRow([]string{name, service.Host, service.Path, service.Target, service.State, tls})
+		table.AddRow([]string{name, service.Host, service.Path, service.Target, service.State, yesNo(service.TLS), yesNo(service.Rollout)})
 	}
 
 	table.Print()
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 type tracker interface {
-	TrackRequest(service, method string, status int, duration time.Duration)
+	TrackRequest(service, method string, status int, rollout bool, duration time.Duration)
 	AddInflightRequest(service string)
 	SubtractInflightRequest(service string)
 }
@@ -24,9 +24,11 @@ func Enable() http.Handler {
 
 type nullTracker struct{}
 
-func (nullTracker) TrackRequest(service, method string, status int, dur time.Duration) {}
-func (nullTracker) AddInflightRequest(service string)                                  {}
-func (nullTracker) SubtractInflightRequest(service string)                             {}
+func (nullTracker) TrackRequest(
+	service, method string, status int, rollout bool, dur time.Duration) {
+}
+func (nullTracker) AddInflightRequest(service string)      {}
+func (nullTracker) SubtractInflightRequest(service string) {}
 
 type prometheusTracker struct {
 	httpRequests     *prometheus.CounterVec
@@ -41,9 +43,9 @@ func NewPrometheusTracker() *prometheusTracker {
 				Name:      "http_requests_total",
 				Namespace: "kamal",
 				Subsystem: "proxy",
-				Help:      "HTTP requests processed, labeled by service, status code and method.",
+				Help:      "HTTP requests processed, labeled by service, status code, method and rollout status.",
 			},
-			[]string{"service", "method", "status"},
+			[]string{"service", "method", "status", "rollout"},
 		),
 
 		httpDuration: prometheus.NewHistogramVec(
@@ -51,10 +53,10 @@ func NewPrometheusTracker() *prometheusTracker {
 				Name:      "http_request_duration_seconds",
 				Namespace: "kamal",
 				Subsystem: "proxy",
-				Help:      "Duration of HTTP requests, labeled by service, status code and method.",
+				Help:      "Duration of HTTP requests, labeled by service, status code, method and rollout status.",
 				Buckets:   prometheus.DefBuckets,
 			},
-			[]string{"service", "method", "status"},
+			[]string{"service", "method", "status", "rollout"},
 		),
 
 		inflightRequests: prometheus.NewGaugeVec(
@@ -73,12 +75,13 @@ func NewPrometheusTracker() *prometheusTracker {
 	return tracker
 }
 
-func (p *prometheusTracker) TrackRequest(service, method string, status int, duration time.Duration) {
+func (p *prometheusTracker) TrackRequest(service, method string, status int, rollout bool, duration time.Duration) {
 	method = normalizeMethod(method)
 	statusString := strconv.Itoa(status)
+	rolloutString := strconv.FormatBool(rollout)
 
-	p.httpRequests.WithLabelValues(service, method, statusString).Inc()
-	p.httpDuration.WithLabelValues(service, method, statusString).Observe(duration.Seconds())
+	p.httpRequests.WithLabelValues(service, method, statusString, rolloutString).Inc()
+	p.httpDuration.WithLabelValues(service, method, statusString, rolloutString).Observe(duration.Seconds())
 }
 
 func (p *prometheusTracker) AddInflightRequest(service string) {

--- a/internal/server/logging_middleware.go
+++ b/internal/server/logging_middleware.go
@@ -20,6 +20,7 @@ var contextKeyRequestContext = contextKey("request-context")
 type loggingRequestContext struct {
 	Service         string
 	Target          string
+	Rollout         bool
 	RequestHeaders  []string
 	ResponseHeaders []string
 	ExcludeMetrics  bool
@@ -87,6 +88,7 @@ func (h *LoggingMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			slog.Int("status", writer.statusCode),
 			slog.String("service", loggingRequestContext.Service),
 			slog.String("target", loggingRequestContext.Target),
+			slog.Bool("rollout", loggingRequestContext.Rollout),
 			slog.Int64("duration", elapsed.Nanoseconds()),
 			slog.String("method", r.Method),
 			slog.Int64("req_content_length", r.ContentLength),
@@ -107,7 +109,7 @@ func (h *LoggingMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.logger.LogAttrs(context.Background(), slog.LevelInfo, "Request", attrs...)
 
 		if !loggingRequestContext.ExcludeMetrics {
-			metrics.Tracker.TrackRequest(loggingRequestContext.Service, r.Method, writer.statusCode, elapsed)
+			metrics.Tracker.TrackRequest(loggingRequestContext.Service, r.Method, writer.statusCode, loggingRequestContext.Rollout, elapsed)
 		}
 	}()
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -53,15 +54,45 @@ type Router struct {
 }
 
 type ServiceDescription struct {
-	Host    string `json:"host"`
-	Path    string `json:"path"`
-	TLS     bool   `json:"tls"`
-	Target  string `json:"target"`
-	State   string `json:"state"`
-	Rollout bool   `json:"rollout"`
+	Hosts        nonNullList        `json:"hosts"`
+	PathPrefixes nonNullList        `json:"path_prefixes"`
+	TLS          bool               `json:"tls"`
+	Targets      nonNullList        `json:"targets"`
+	ReadTargets  nonNullList        `json:"read_targets"`
+	State        string             `json:"state"`
+	Rollout      RolloutDescription `json:"rollout"`
+}
+
+func (sd ServiceDescription) DisplayHosts() string {
+	return strings.Join(sd.Hosts, ",")
+}
+
+func (sd ServiceDescription) DisplayPaths() string {
+	return strings.Join(sd.PathPrefixes, ",")
+}
+
+func (sd ServiceDescription) DisplayTargets() string {
+	return strings.Join(slices.Concat(sd.Targets, sd.ReadTargets), ",")
+}
+
+type RolloutDescription struct {
+	Enabled     bool        `json:"enabled"`
+	Percentage  int         `json:"percentage"`
+	Allowlist   nonNullList `json:"allowlist"`
+	Targets     nonNullList `json:"targets"`
+	ReadTargets nonNullList `json:"read_targets"`
 }
 
 type ServiceDescriptionMap map[string]ServiceDescription
+
+type nonNullList []string
+
+func (l nonNullList) MarshalJSON() ([]byte, error) {
+	if l == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]string(l))
+}
 
 func NewRouter(statePath string) *Router {
 	return &Router{

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -53,11 +53,12 @@ type Router struct {
 }
 
 type ServiceDescription struct {
-	Host   string `json:"host"`
-	Path   string `json:"path"`
-	TLS    bool   `json:"tls"`
-	Target string `json:"target"`
-	State  string `json:"state"`
+	Host    string `json:"host"`
+	Path    string `json:"path"`
+	TLS     bool   `json:"tls"`
+	Target  string `json:"target"`
+	State   string `json:"state"`
+	Rollout bool   `json:"rollout"`
 }
 
 type ServiceDescriptionMap map[string]ServiceDescription
@@ -281,21 +282,7 @@ func (r *Router) ListActiveServices() ServiceDescriptionMap {
 	r.withReadLock(func() error {
 		for name, service := range r.services.All() {
 			if service.active != nil {
-				host := strings.Join(service.options.Hosts, ",")
-				if host == "" {
-					host = "*"
-				}
-
-				path := strings.Join(service.options.PathPrefixes, ",")
-				target := strings.Join(service.active.Targets().Names(), ",")
-
-				result[name] = ServiceDescription{
-					Host:   host,
-					Path:   path,
-					Target: target,
-					TLS:    service.options.TLSEnabled,
-					State:  service.pauseController.GetState().String(),
-				}
+				result[name] = service.Describe()
 			}
 		}
 		return nil

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -828,6 +828,65 @@ func TestRouter_RemovingRollout(t *testing.T) {
 	assert.Equal(t, ErrorRolloutTargetNotSet, router.SetRolloutSplit("service1", 0, []string{"1"}))
 }
 
+func TestRouter_ListActiveServices(t *testing.T) {
+	router := testRouter(t)
+	_, first := testBackend(t, "first", http.StatusOK)
+	_, second := testBackend(t, "second", http.StatusOK)
+	_, third := testBackend(t, "third", http.StatusOK)
+
+	tlsServiceOptions := defaultServiceOptions
+	tlsServiceOptions.Hosts = []string{"example.com"}
+	tlsServiceOptions.TLSEnabled = true
+	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, tlsServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
+
+	pathServiceOptions := defaultServiceOptions
+	pathServiceOptions.PathPrefixes = []string{"/app"}
+	require.NoError(t, router.DeployService("service2", []string{second}, defaultEmptyReaders, pathServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
+
+	services := router.ListActiveServices()
+	assert.Len(t, services, 2)
+	assert.Equal(t, ServiceDescription{
+		Host:    "example.com",
+		Path:    "/",
+		Target:  first,
+		TLS:     true,
+		State:   "running",
+		Rollout: false,
+	}, services["service1"])
+	assert.Equal(t, ServiceDescription{
+		Host:    "*",
+		Path:    "/app",
+		Target:  second,
+		TLS:     false,
+		State:   "running",
+		Rollout: false,
+	}, services["service2"])
+
+	require.NoError(t, router.PauseService("service1", time.Second, time.Second))
+
+	services = router.ListActiveServices()
+	assert.Equal(t, "paused", services["service1"].State)
+	assert.Equal(t, "running", services["service2"].State)
+
+	require.NoError(t, router.ResumeService("service1"))
+	require.NoError(t, router.SetRolloutTargets("service2", []string{third}, defaultEmptyReaders, defaultDeploymentOptions))
+
+	services = router.ListActiveServices()
+	assert.False(t, services["service2"].Rollout)
+
+	require.NoError(t, router.EnableRollout("service2"))
+
+	services = router.ListActiveServices()
+	assert.Equal(t, "running", services["service1"].State)
+	assert.False(t, services["service1"].Rollout)
+	assert.True(t, services["service2"].Rollout)
+
+	require.NoError(t, router.DisableRollout("service2"))
+
+	services = router.ListActiveServices()
+	assert.False(t, services["service2"].Rollout)
+}
+
 func TestRouter_RestoreLastSavedState(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/gob"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -833,34 +835,45 @@ func TestRouter_ListActiveServices(t *testing.T) {
 	_, first := testBackend(t, "first", http.StatusOK)
 	_, second := testBackend(t, "second", http.StatusOK)
 	_, third := testBackend(t, "third", http.StatusOK)
+	_, fourth := testBackend(t, "fourth", http.StatusOK)
+
+	_, reader := testBackend(t, "reader", http.StatusOK)
 
 	tlsServiceOptions := defaultServiceOptions
 	tlsServiceOptions.Hosts = []string{"example.com"}
 	tlsServiceOptions.TLSEnabled = true
-	require.NoError(t, router.DeployService("service1", []string{first}, defaultEmptyReaders, tlsServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
+	require.NoError(t, router.DeployService("service1", []string{first}, []string{reader}, tlsServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
 
 	pathServiceOptions := defaultServiceOptions
 	pathServiceOptions.PathPrefixes = []string{"/app"}
 	require.NoError(t, router.DeployService("service2", []string{second}, defaultEmptyReaders, pathServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
 
+	mixedHostServiceOptions := defaultServiceOptions
+	mixedHostServiceOptions.Hosts = []string{"example.org", ""}
+	require.NoError(t, router.DeployService("service3", []string{fourth}, defaultEmptyReaders, mixedHostServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
+
 	services := router.ListActiveServices()
-	assert.Len(t, services, 2)
-	assert.Equal(t, ServiceDescription{
-		Host:    "example.com",
-		Path:    "/",
-		Target:  first,
-		TLS:     true,
-		State:   "running",
-		Rollout: false,
-	}, services["service1"])
-	assert.Equal(t, ServiceDescription{
-		Host:    "*",
-		Path:    "/app",
-		Target:  second,
-		TLS:     false,
-		State:   "running",
-		Rollout: false,
-	}, services["service2"])
+	assert.Len(t, services, 3)
+
+	service1 := services["service1"]
+	assert.Equal(t, nonNullList{"example.com"}, service1.Hosts)
+	assert.Equal(t, nonNullList{"/"}, service1.PathPrefixes)
+	assert.Equal(t, nonNullList{first}, service1.Targets)
+	assert.Equal(t, nonNullList{reader}, service1.ReadTargets)
+	assert.True(t, service1.TLS)
+	assert.Equal(t, "running", service1.State)
+	assert.Equal(t, RolloutDescription{Allowlist: nonNullList{}}, service1.Rollout)
+
+	service2 := services["service2"]
+	assert.Equal(t, nonNullList{"*"}, service2.Hosts)
+	assert.Equal(t, nonNullList{"/app"}, service2.PathPrefixes)
+	assert.Equal(t, nonNullList{second}, service2.Targets)
+	assert.Empty(t, service2.ReadTargets)
+	assert.False(t, service2.TLS)
+	assert.Equal(t, "running", service2.State)
+	assert.False(t, service2.Rollout.Enabled)
+
+	assert.Equal(t, nonNullList{"example.org", "*"}, services["service3"].Hosts)
 
 	require.NoError(t, router.PauseService("service1", time.Second, time.Second))
 
@@ -872,19 +885,48 @@ func TestRouter_ListActiveServices(t *testing.T) {
 	require.NoError(t, router.SetRolloutTargets("service2", []string{third}, defaultEmptyReaders, defaultDeploymentOptions))
 
 	services = router.ListActiveServices()
-	assert.False(t, services["service2"].Rollout)
+	assert.Equal(t, nonNullList{third}, services["service2"].Rollout.Targets)
+	assert.False(t, services["service2"].Rollout.Enabled)
 
+	require.NoError(t, router.SetRolloutSplit("service2", 50, []string{"key1"}))
 	require.NoError(t, router.EnableRollout("service2"))
 
 	services = router.ListActiveServices()
 	assert.Equal(t, "running", services["service1"].State)
-	assert.False(t, services["service1"].Rollout)
-	assert.True(t, services["service2"].Rollout)
+	assert.False(t, services["service1"].Rollout.Enabled)
+	assert.Equal(t, RolloutDescription{
+		Enabled:     true,
+		Percentage:  50,
+		Allowlist:   nonNullList{"key1"},
+		Targets:     nonNullList{third},
+		ReadTargets: nonNullList{},
+	}, services["service2"].Rollout)
 
 	require.NoError(t, router.DisableRollout("service2"))
 
 	services = router.ListActiveServices()
-	assert.False(t, services["service2"].Rollout)
+	rollout := services["service2"].Rollout
+	assert.False(t, rollout.Enabled)
+	assert.Equal(t, 50, rollout.Percentage)
+	assert.Equal(t, nonNullList{"key1"}, rollout.Allowlist)
+}
+
+func TestRouter_ListActiveServices_EmptyListsSurviveGobAsJSON(t *testing.T) {
+	router := testRouter(t)
+	_, target := testBackend(t, "first", http.StatusOK)
+	require.NoError(t, router.DeployService("service1", []string{target}, defaultEmptyReaders, defaultServiceOptions, defaultTargetOptions, defaultDeploymentOptions))
+
+	var buffer bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buffer).Encode(router.ListActiveServices()))
+
+	var services ServiceDescriptionMap
+	require.NoError(t, gob.NewDecoder(&buffer).Decode(&services))
+
+	output, err := json.Marshal(services)
+	require.NoError(t, err)
+	assert.NotContains(t, string(output), "null")
+	assert.Contains(t, string(output), `"read_targets":[]`)
+	assert.Contains(t, string(output), `"allowlist":[]`)
 }
 
 func TestRouter_RestoreLastSavedState(t *testing.T) {

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -335,6 +335,26 @@ type marshalledService struct {
 	LegacyPathPrefixes  []string `json:"path_prefixes,omitempty"`
 }
 
+func (s *Service) Describe() ServiceDescription {
+	s.serviceLock.RLock()
+	active, controller := s.active, s.currentRolloutController()
+	s.serviceLock.RUnlock()
+
+	host := strings.Join(s.options.Hosts, ",")
+	if host == "" {
+		host = "*"
+	}
+
+	return ServiceDescription{
+		Host:    host,
+		Path:    strings.Join(s.options.PathPrefixes, ","),
+		Target:  strings.Join(active.Targets().Names(), ","),
+		TLS:     s.options.TLSEnabled,
+		State:   s.pauseController.GetState().String(),
+		Rollout: controller.Enabled,
+	}
+}
+
 func (s *Service) MarshalJSON() ([]byte, error) {
 	s.serviceLock.RLock()
 	active, rollout, rolloutController := s.active, s.rollout, s.rolloutController

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -337,22 +337,42 @@ type marshalledService struct {
 
 func (s *Service) Describe() ServiceDescription {
 	s.serviceLock.RLock()
-	active, controller := s.active, s.currentRolloutController()
+	active, rollout, controller := s.active, s.rollout, s.currentRolloutController()
 	s.serviceLock.RUnlock()
 
-	host := strings.Join(s.options.Hosts, ",")
-	if host == "" {
-		host = "*"
+	hosts := make([]string, 0, len(s.options.Hosts))
+	for _, host := range s.options.Hosts {
+		if host == "" {
+			host = "*"
+		}
+		hosts = append(hosts, host)
 	}
 
+	targets, readers := targetNames(active)
+	rolloutTargets, rolloutReaders := targetNames(rollout)
+
 	return ServiceDescription{
-		Host:    host,
-		Path:    strings.Join(s.options.PathPrefixes, ","),
-		Target:  strings.Join(active.Targets().Names(), ","),
-		TLS:     s.options.TLSEnabled,
-		State:   s.pauseController.GetState().String(),
-		Rollout: controller.Enabled,
+		Hosts:        hosts,
+		PathPrefixes: s.options.PathPrefixes,
+		Targets:      targets,
+		ReadTargets:  readers,
+		TLS:          s.options.TLSEnabled,
+		State:        s.pauseController.GetState().String(),
+		Rollout: RolloutDescription{
+			Enabled:     controller.Enabled,
+			Percentage:  controller.Percentage,
+			Allowlist:   controller.Allowlist,
+			Targets:     rolloutTargets,
+			ReadTargets: rolloutReaders,
+		},
 	}
+}
+
+func targetNames(lb *LoadBalancer) (targets, readers []string) {
+	if lb == nil {
+		return nil, nil
+	}
+	return lb.WriteTargets().Names(), lb.ReadTargets().Names()
 }
 
 func (s *Service) MarshalJSON() ([]byte, error) {
@@ -360,17 +380,13 @@ func (s *Service) MarshalJSON() ([]byte, error) {
 	active, rollout, rolloutController := s.active, s.rollout, s.rolloutController
 	s.serviceLock.RUnlock()
 
-	var rolloutTargets []string
-	var rolloutReaders []string
-	if rollout != nil {
-		rolloutTargets = rollout.WriteTargets().Names()
-		rolloutReaders = rollout.ReadTargets().Names()
-	}
+	activeTargets, activeReaders := targetNames(active)
+	rolloutTargets, rolloutReaders := targetNames(rollout)
 
 	return json.Marshal(marshalledService{
 		Name:              s.name,
-		ActiveTargets:     active.WriteTargets().Names(),
-		ActiveReaders:     active.ReadTargets().Names(),
+		ActiveTargets:     activeTargets,
+		ActiveReaders:     activeReaders,
 		RolloutTargets:    rolloutTargets,
 		RolloutReaders:    rolloutReaders,
 		Options:           s.options,

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -524,6 +524,7 @@ func (s *Service) loadBalancerForRequest(req *http.Request) *LoadBalancer {
 	lb := s.active
 	if s.rollout != nil && s.rolloutController != nil && s.rolloutController.RequestUsesRolloutGroup(req) {
 		slog.Debug("Using rollout for request", "service", s.name, "path", req.URL.Path)
+		LoggingRequestContext(req).Rollout = true
 		lb = s.rollout
 	}
 


### PR DESCRIPTION
- Add a "Rollout" column to the `list` output, to easily see when rollout is on for a service
- Add a `--json` flag to `list` which writes detailed, machine-readable information about the services (includes rollout information, among other things)
- Add a `rollout` label to Prometheus request metrics and access logs (values are `true` and `false`)