### PR TITLE
Add version command and log version at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN make
+ARG VERSION=dev
+RUN make build VERSION=$VERSION
 
 FROM ubuntu:noble-20251013 AS base
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 .PHONY: build test lint check bench docker
 
+VERSION ?= $(shell git describe --tags --always --dirty)
+LDFLAGS := -ldflags "-X 'github.com/basecamp/kamal-proxy/internal/version.Version=$(VERSION)'"
+
 build:
-	CGO_ENABLED=0 go build -trimpath -o bin/ ./cmd/...
+	CGO_ENABLED=0 go build -trimpath $(LDFLAGS) -o bin/ ./cmd/...
 
 test:
 	go test ./...

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -28,6 +28,7 @@ func Execute() {
 	rootCmd.AddCommand(newResumeCommand().cmd)
 	rootCmd.AddCommand(newListCommand().cmd)
 	rootCmd.AddCommand(newRolloutCommand().cmd)
+	rootCmd.AddCommand(newVersionCommand().cmd)
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/kamal-proxy/internal/server"
+	"github.com/basecamp/kamal-proxy/internal/version"
 )
 
 type runCommand struct {
@@ -35,6 +36,7 @@ func newRunCommand() *runCommand {
 
 func (c *runCommand) run(cmd *cobra.Command, args []string) error {
 	c.setLogger()
+	slog.Info("Starting kamal-proxy", "version", version.Version)
 
 	router := server.NewRouter(globalConfig.StatePath())
 	router.RestoreLastSavedState()

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/kamal-proxy/internal/version"
+)
+
+type versionCommand struct {
+	cmd *cobra.Command
+}
+
+func newVersionCommand() *versionCommand {
+	versionCommand := &versionCommand{}
+	versionCommand.cmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.Version)
+		},
+	}
+
+	return versionCommand
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "dev"

--- a/script/release
+++ b/script/release
@@ -28,6 +28,8 @@ docker buildx build \
   --tag basecamp/kamal-proxy:${TAG} \
   --tag basecamp/kamal-proxy:latest \
   --label "org.opencontainers.image.title=kamal-proxy" \
+  --label "org.opencontainers.image.version=${TAG}" \
+  --build-arg VERSION=${TAG} \
   --push .
 
 git push origin tag ${TAG}


### PR DESCRIPTION
Bake a version string into the binary at build time. Local builds derive it from `git describe`; the release script pins the Docker image to the tag it creates via a build arg. Unset, the version is "dev".