### PR TITLE
Close the request buffer when the request ends

### DIFF
--- a/internal/server/request_buffer_middleware.go
+++ b/internal/server/request_buffer_middleware.go
@@ -35,6 +35,12 @@ func (h *RequestBufferMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Close the buffer ourselves once the request is done, so the spill file
+	// is always removed. Downstream handlers cannot be relied on to close it:
+	// httputil.ReverseProxy in Go 1.26 wrapped the outbound body so that its
+	// Close was a no-op, and every spilled request left its file behind.
+	defer requestBuffer.Close()
+
 	r.Body = requestBuffer
 	h.next.ServeHTTP(w, r)
 }

--- a/internal/server/request_buffer_middleware.go
+++ b/internal/server/request_buffer_middleware.go
@@ -36,9 +36,7 @@ func (h *RequestBufferMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Close the buffer ourselves once the request is done, so the spill file
-	// is always removed. Downstream handlers cannot be relied on to close it:
-	// httputil.ReverseProxy in Go 1.26 wrapped the outbound body so that its
-	// Close was a no-op, and every spilled request left its file behind.
+	// is always removed (even if the downstream handler doesn't close it).
 	defer requestBuffer.Close()
 
 	r.Body = requestBuffer

--- a/internal/server/request_buffer_middleware_test.go
+++ b/internal/server/request_buffer_middleware_test.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"bufio"
+	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -65,4 +68,32 @@ func TestRequestBufferMiddleware_MalformedChunkedEncoding(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRequestBufferMiddleware_RemovesSpillFileWhenRequestEnds(t *testing.T) {
+	var spillFile string
+
+	middleware := WithRequestBufferMiddleware(4, 1024, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buffer, ok := r.Body.(*Buffer)
+		require.True(t, ok)
+		require.NotNil(t, buffer.diskBuffer, "expected the body to spill to disk")
+		spillFile = buffer.diskBuffer.Name()
+
+		// Read the body without closing it, like a downstream handler that
+		// leaves closing to whoever owns the body.
+		_, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "http://app.example.com/somepath", strings.NewReader("a body larger than the memory buffer"))
+	rec := httptest.NewRecorder()
+
+	middleware.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	require.NotEmpty(t, spillFile)
+
+	_, err := os.Stat(spillFile)
+	assert.ErrorIs(t, err, fs.ErrNotExist, "spill file should be removed once the request is done")
 }

--- a/internal/server/request_buffer_middleware_test.go
+++ b/internal/server/request_buffer_middleware_test.go
@@ -3,11 +3,9 @@ package server
 import (
 	"bufio"
 	"io"
-	"io/fs"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -94,6 +92,5 @@ func TestRequestBufferMiddleware_RemovesSpillFileWhenRequestEnds(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
 	require.NotEmpty(t, spillFile)
 
-	_, err := os.Stat(spillFile)
-	assert.ErrorIs(t, err, fs.ErrNotExist, "spill file should be removed once the request is done")
+	assert.NoFileExists(t, spillFile, "spill file should be removed once the request is done")
 }


### PR DESCRIPTION
The request buffer middleware hands its `Buffer` to the next handler as `r.Body` and leaves closing it to whoever reads it. Only `Close` removes the spill file that a body over the memory limit is written to, so anything downstream that doesn't close the body leaks a `proxy-buffer-*` file in `/tmp`.

In practice that closer was `httputil.ReverseProxy`, and Go 1.26 wrapped its outbound body so that `Close` is a no-op ([CL 722160](https://go-review.googlesource.com/c/go/+/722160), reverted in Go 1.27 by [CL 793041](https://go-review.googlesource.com/c/go/+/793041) "so a better approach can be implemented"). The `v0.10.0-rc1` image is built with Go 1.26.7, and on HEY's mail nodes, where most inbound emails exceed the 1 MB memory buffer, its container grew to 8 GB of leaked spill files in 34 hours. `v0.9.2` (Go 1.25.5) and `v0.10.0` (Go 1.27.1) don't leak, but only because the reverse proxy happens to close the body in those Go versions.

This closes the buffer from the middleware itself, the way the response buffer middleware already does, so the spill file's lifetime is ours regardless of what Go does next. `Buffer.Close` is guarded by `sync.Once`, so the reverse proxy closing it as well stays harmless.

The new test spills a body to disk, reads it without closing, and checks the file is gone once the handler returns. It fails on `main` and passes with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5qdJSipYPHF2hpfuEeyGg
