### PR TITLE
Relay 1xx responses through the response buffer instead of latching them

### DIFF
--- a/internal/server/logging_middleware.go
+++ b/internal/server/logging_middleware.go
@@ -138,7 +138,9 @@ func newLoggerResponseWriter(w http.ResponseWriter) *loggerResponseWriter {
 
 // WriteHeader is used to capture the status code
 func (r *loggerResponseWriter) WriteHeader(statusCode int) {
-	r.statusCode = statusCode
+	if !isInformational(statusCode) {
+		r.statusCode = statusCode
+	}
 	r.ResponseWriter.WriteHeader(statusCode)
 }
 

--- a/internal/server/response_buffer_middleware.go
+++ b/internal/server/response_buffer_middleware.go
@@ -43,6 +43,12 @@ func (h *ResponseBufferMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	}
 }
 
+// isInformational reports whether statusCode is a 1xx interim response. 101
+// Switching Protocols is excluded: it ends the HTTP exchange, so it is final.
+func isInformational(statusCode int) bool {
+	return statusCode >= 100 && statusCode < 200 && statusCode != http.StatusSwitchingProtocols
+}
+
 type bufferedResponseWriter struct {
 	http.ResponseWriter
 	statusCode    int
@@ -73,6 +79,17 @@ func (w *bufferedResponseWriter) Header() http.Header {
 }
 
 func (w *bufferedResponseWriter) WriteHeader(statusCode int) {
+	if isInformational(statusCode) {
+		// 1xx responses precede the final response rather than replace it.
+		// httputil.ReverseProxy relays them from the upstream, for example the
+		// 100 Continue a backend sends when the client used Expect:
+		// 100-continue. Pass them straight through and keep waiting for the
+		// real status, otherwise we'd latch the 1xx as the final one and the
+		// client would get an implicit 200 instead.
+		w.ResponseWriter.WriteHeader(statusCode)
+		return
+	}
+
 	if !w.headerWritten {
 		w.statusCode = statusCode
 		w.headerWritten = true

--- a/internal/server/response_buffer_middleware_test.go
+++ b/internal/server/response_buffer_middleware_test.go
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResponseBufferMiddleware(t *testing.T) {
@@ -236,4 +238,30 @@ func TestBufferedResponseWriter_ShouldSwitchToUnbuffered(t *testing.T) {
 			assert.Equal(t, tc.expected, result, tc.description)
 		})
 	}
+}
+
+func TestResponseBufferMiddleware_InformationalResponsesAreRelayedNotLatched(t *testing.T) {
+	out := &strings.Builder{}
+	logger := slog.New(slog.NewJSONHandler(out, nil))
+
+	// Like an upstream answering Expect: 100-continue: an interim 100, then
+	// the real response. httputil.ReverseProxy relays the 100 to us through
+	// WriteHeader before the final status arrives.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusContinue)
+		w.Header().Set("X-Final", "yes")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	middleware := WithLoggingMiddleware(logger, 80, 443, WithResponseBufferMiddleware(1024, 4096, handler))
+	server := httptest.NewServer(middleware)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Post(server.URL+"/somepath", "text/plain", strings.NewReader("hello"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "yes", resp.Header.Get("X-Final"))
+	assert.Contains(t, out.String(), `"status":204`)
 }


### PR DESCRIPTION
Noticed on HEY while verifying #248: in kamal-proxy's access logs and metrics, every inbound email over 1 MB shows `"status":100`, while the small ones show `204`. The count matched the over-1 MB bodies exactly: curl adds `Expect: 100-continue` above 1 MiB, Puma answers with an interim `100 Continue`, and `httputil.ReverseProxy` relays that 1xx to us by calling `WriteHeader(100)` before the final `WriteHeader(204)`.

`bufferedResponseWriter` treats the first `WriteHeader` as the final status. It latches the 100, ignores the 204, and `Send` then writes the 100 as an informational response with no final status behind it, so the client actually receives an implicit `200 OK` instead of the upstream's `204`. The logging middleware records 100 as the request's status, and so does the metrics tracker.

This passes 1xx responses (other than 101, which is terminal) straight through the buffered writer and keeps waiting for the real status, and stops the logger from recording them as the request's status.

The test drives a 100-then-204 handler through the logging and response buffer middlewares on a real `httptest.Server`. On `main` it fails with the client seeing 200 and the log line carrying `"status":100`; with the change the client sees 204 and so does the log.

Cosmetic for the mail relay, which only checks for a 2xx, but it makes the status logs and `kamal_proxy_http_response_*` metrics wrong for exactly the requests one tends to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
